### PR TITLE
fix: apply correct ESM exports map

### DIFF
--- a/configs/rollup/src/index.js
+++ b/configs/rollup/src/index.js
@@ -32,7 +32,7 @@ exports.generateRollupConfig = function generateRollupConfig({ packageDir, entry
       output: [
         {
           format,
-          ...(isESMFormat ? { dir: output, entryFileNames: `[name].mjs` } : { file: output }),
+          ...(isESMFormat ? { dir: path.dirname(output), entryFileNames: `[name]${path.extname(output)}` } : { file: output }),
         },
       ],
       plugins: [
@@ -52,12 +52,11 @@ exports.generateRollupConfig = function generateRollupConfig({ packageDir, entry
   }
 
   function buildCJS(input, output) {
-    const filename = path.parse(input).name;
     return buildJS(input, output, 'cjs');
   }
 
   function buildESM(input, output) {
-    return buildJS(input, path.dirname(output), 'es');
+    return buildJS(input, output, 'es');
   }
 
   return entrypoints.flatMap(entrypoint => {

--- a/packages/react/impression-area/package.json
+++ b/packages/react/impression-area/package.json
@@ -60,9 +60,7 @@
         "types": "./dist/testing/index.d.ts"
       }
     },
-    "import": "./esm/index.mjs",
     "main": "./dist/index.js",
-    "module": "./esm/index.js",
     "types": "./dist/index.d.ts"
   },
   "gitHead": "bd6da79df8f3177ac1f13eac0edbf5b7549ea3d3"

--- a/packages/react/use-preserved-callback/package.json
+++ b/packages/react/use-preserved-callback/package.json
@@ -20,9 +20,7 @@
       "./package.json": "./package.json"
     },
     "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "module": "./esm/index.js",
-    "import": "./esm/index.js"
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "prepack": "yarn build",

--- a/packages/react/use-ref-effect/package.json
+++ b/packages/react/use-ref-effect/package.json
@@ -20,9 +20,7 @@
       "./package.json": "./package.json"
     },
     "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "module": "./esm/index.js",
-    "import": "./esm/index.mjs"
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "prepack": "yarn build",


### PR DESCRIPTION
Closes: #12 

## 어떤 목적의 PR인가요?

- `@toss/impression-area`에서 잘못된 ESM export 경로를 수정합니다.
- Export map 기반으로 ESM 번들링 파일(specially extension)을 생성하기 위해 rollup config를 수정합니다.

===

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Other : <!-- Purpose -->

## 내용을 설명해주세요

<!--
    변경사항에 대해 알기 쉽게 설명해주세요.
    리뷰어가 특별히 더 집중해서 봐야 하는 부분이 있다면 알려주세요.
 -->

1. 외부에서 사용 시 entry 경로를 exports.import(ESM) exports.require(CJS)로 바라보게 하기 위해 package.json에 publishConfig안에 있는 `import`, `module` 필드는 삭제했습니다.
2. rollup config 내 ESM 번들링을 위한 output 파일 경로의 확장자를 `.mjs`로 명시하는 것 대신에 exports.import 파일 확장자로 사용하게끔 수정하였습니다.

## 체크리스트

- [x] 아래 항목들을 모두 확인하였습니다.

1. PR 내용을 잘 설명하였습니다
3. 문서화를 충분히 하였습니다 (필요시)
4. 테스트가 충분히 작성되었습니다 (필요시)
