### PR TITLE
fix: Fix incorrect `module` field in package.json

### DIFF
--- a/packages/common/utility-types/package.json
+++ b/packages/common/utility-types/package.json
@@ -23,10 +23,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "import": "esm/index.js",
-    "main": "dist/index.js",
-    "module": "esm/index.js",
-    "types": "dist/index.d.ts"
+    "main": "./dist/index.js"
   },
   "gitHead": "bd6da79df8f3177ac1f13eac0edbf5b7549ea3d3"
 }

--- a/packages/react/impression-area/package.json
+++ b/packages/react/impression-area/package.json
@@ -61,7 +61,7 @@
     },
     "import": "./esm/index.mjs",
     "main": "./dist/index.js",
-    "module": "./esm/index.js",
+    "module": "./esm/index.mjs",
     "types": "./dist/index.d.ts"
   },
   "gitHead": "bd6da79df8f3177ac1f13eac0edbf5b7549ea3d3"


### PR DESCRIPTION
## 어떤 목적의 PR인가요?

Fixes https://github.com/toss/slash/issues/12

===

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Other : <!-- Purpose -->

## 내용을 설명해주세요

An incorrect filepath is specified in `@toss/impression-area`'s package.json `module` field. We fix this issue.

Also, `@toss/utility-types` is a typescript-only package. There is no need for ESM files, so we remove other fields in `publishConfig`.

`@toss/impression-area` 패키지의 `module` 필드가 올바른 확장자를 쓰고 있지 않아서 수정합니다.

`@toss/utility-types` 패키지는 TypeScript 전용이므로 ESM 관련 대응을 할 필요가 없습니다. `publishConfig` 에서 관련 설정을 제거합니다.

## 체크리스트

- [x] 아래 항목들을 모두 확인하였습니다.

1. PR 내용을 잘 설명하였습니다
2. 문서화를 충분히 하였습니다 (필요시)
3. 테스트가 충분히 작성되었습니다 (필요시)
