### PR TITLE
refactor: buildESM at rollup config

### DIFF
--- a/configs/rollup/src/index.js
+++ b/configs/rollup/src/index.js
@@ -32,7 +32,7 @@ exports.generateRollupConfig = function generateRollupConfig({ packageDir, entry
       output: [
         {
           format,
-          ...(isESMFormat ? { dir: output, entryFileNames: `[name].mjs` } : { file: output }),
+          ...(isESMFormat ? { dir: path.dirname(output), entryFileNames: `[name]${path.extname(output)}` } : { file: output }),
         },
       ],
       plugins: [
@@ -52,12 +52,11 @@ exports.generateRollupConfig = function generateRollupConfig({ packageDir, entry
   }
 
   function buildCJS(input, output) {
-    const filename = path.parse(input).name;
     return buildJS(input, output, 'cjs');
   }
 
   function buildESM(input, output) {
-    return buildJS(input, path.dirname(output), 'es');
+    return buildJS(input, output, 'es');
   }
 
   return entrypoints.flatMap(entrypoint => {

--- a/packages/react/react/src/hooks/useBodyClass.ts
+++ b/packages/react/react/src/hooks/useBodyClass.ts
@@ -1,4 +1,3 @@
-import { isServer } from '@toss/utils';
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
 /**


### PR DESCRIPTION
## 어떤 목적의 PR인가요?

- 사용하지 않는 module을 import하는 코드를 삭제합니다.
- #12  관련하여 고정된 `.mjs` 대신 conditional exports map 기반으로 ESM 번들링 파일(specially extension)을 생성하기 위해 rollup config를 수정합니다.

===

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Other : <!-- Purpose -->

## 내용을 설명해주세요

<!--
    변경사항에 대해 알기 쉽게 설명해주세요.
    리뷰어가 특별히 더 집중해서 봐야 하는 부분이 있다면 알려주세요.
 -->

- `packages/react/react/src/hooks/useBodyClass.ts`에서 사용되지 않는 module을 import하는 코드를 삭제하였습니다.
- rollup config 내 ESM 번들링을 위한 output 파일 경로의 확장자를 .mjs로 명시하는 것 대신에 exports.import 파일 확장자로 사용하게끔 수정하였습니다.

## 체크리스트

- [x] 아래 항목들을 모두 확인하였습니다.

1. PR 내용을 잘 설명하였습니다
2. 문서화를 충분히 하였습니다 (필요시)
3. 테스트가 충분히 작성되었습니다 (필요시)
