### PR TITLE
test(utils): Add test code for generateID

### DIFF
--- a/packages/common/utils/src/generateID.spec.ts
+++ b/packages/common/utils/src/generateID.spec.ts
@@ -1,21 +1,19 @@
-describe('generateID는', () => {
-  beforeEach(() => {
-    jest.resetModules();
+import { generateID } from './generateID';
+
+describe('generateID should', () => {
+  it('return different string values each time it is called', () => {
+    const id1 = generateID();
+    const id2 = generateID();
+    const id3 = generateID();
+
+    expect(id1).not.toEqual(id2);
+    expect(id1).not.toEqual(id3);
+    expect(id2).not.toEqual(id3);
   });
 
-  it('순서대로 고유한 ID를 생성합니다.', () => {
-    import('./generateID').then(({ generateID }) => {
-      expect(generateID()).toEqual('1');
-      expect(generateID()).toEqual('2');
-      expect(generateID()).toEqual('3');
-    });
-  });
+  it('start with the prefix, if given', () => {
+    const id = generateID('toss');
 
-  it('prefix를 포함한 고유의 ID를 생성합니다.', () => {
-    import('./generateID').then(({ generateID }) => {
-      expect(generateID('toss')).toEqual('toss1');
-      expect(generateID('toss')).toEqual('toss2');
-      expect(generateID('toss')).toEqual('toss3');
-    });
+    expect(id.startsWith('toss')).toBe(true);
   });
 });

--- a/packages/common/utils/src/generateID.spec.ts
+++ b/packages/common/utils/src/generateID.spec.ts
@@ -1,0 +1,21 @@
+describe('generateID는', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('순서대로 고유한 ID를 생성합니다.', () => {
+    import('./generateID').then(({ generateID }) => {
+      expect(generateID()).toEqual('1');
+      expect(generateID()).toEqual('2');
+      expect(generateID()).toEqual('3');
+    });
+  });
+
+  it('prefix를 포함한 고유의 ID를 생성합니다.', () => {
+    import('./generateID').then(({ generateID }) => {
+      expect(generateID('toss')).toEqual('toss1');
+      expect(generateID('toss')).toEqual('toss2');
+      expect(generateID('toss')).toEqual('toss3');
+    });
+  });
+});


### PR DESCRIPTION
## Overview

I wrote test code for generateID which belong to @toss/utils To ensure stability, I have written a test code


`nextUniqueId` which is local variable in generateID should be initialized to 0 for every test case
so I used jest.resetModules 
resetModules help our individual test code run independently from other test cases

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed. => I made test case !
