### PR TITLE
chore(utils): fix wrong example of maskName function

### DIFF
--- a/packages/common/utils/src/format.ts
+++ b/packages/common/utils/src/format.ts
@@ -22,7 +22,7 @@
  * maskName('나토스') // '나*스'
  * maskName('제갈토스') // '제**스'
  * maskName('NA TO SEU') // 'N*******U'
- * maskName('박토스', { maskChar: '#' }) // '허#'
+ * maskName('박토스', { maskChar: '#' }) // '박#스'
  */
 export function maskName(name: string, { maskChar = '*' }: { maskChar?: string } = {}) {
   const firstLetter = name.slice(0, 1);


### PR DESCRIPTION
## Overview

fix wrong example of maskName function

### before
![image](https://user-images.githubusercontent.com/29690394/195386343-cfbaf92c-ab62-4866-834f-68b3733e8f21.png)

### after
![image](https://user-images.githubusercontent.com/29690394/195386369-d0781e84-6d9f-45af-9b86-3904d7024344.png)


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
