### PR TITLE
refactor(emotion-utils): union type reused by predefined type 

### DIFF
--- a/packages/react/emotion-utils/src/coerceCssPixelValue.ts
+++ b/packages/react/emotion-utils/src/coerceCssPixelValue.ts
@@ -1,3 +1,5 @@
+import { CSSPixelValue } from './types';
+
 /**
  * @name coerceCssPixelValue
  * @description CSS value를 string value로 변경합니다.
@@ -12,6 +14,6 @@
  * coerceCssPixelValue('4px');
  * // => '4px'
  */
-export function coerceCssPixelValue(value: string | number): string {
+export function coerceCssPixelValue(value: CSSPixelValue): string {
   return typeof value === 'string' ? value : `${value}px`;
 }

--- a/packages/react/emotion-utils/src/mediaQuery.ts
+++ b/packages/react/emotion-utils/src/mediaQuery.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { coerceCssPixelValue } from './coerceCssPixelValue';
+import { CSSPixelValue } from './types';
 
 /**
  * Media query를 쉽게 작성할 수 있는 유틸리티 입니다.
@@ -20,8 +21,8 @@ export const mediaQuery = (query: string) => (template: TemplateStringsArray) =>
     }
   `;
 
-export const mediaQueryScreenAndMaxWidth = (maxWidth: number | string) =>
+export const mediaQueryScreenAndMaxWidth = (maxWidth: CSSPixelValue) =>
   mediaQuery(`screen and (max-width: ${coerceCssPixelValue(maxWidth)})`);
 
-export const mediaQueryScreenAndMinWidth = (minWidth: number | string) =>
+export const mediaQueryScreenAndMinWidth = (minWidth: CSSPixelValue) =>
   mediaQuery(`screen and (min-width: ${coerceCssPixelValue(minWidth)})`);

--- a/packages/react/emotion-utils/src/spacing.tsx
+++ b/packages/react/emotion-utils/src/spacing.tsx
@@ -1,14 +1,14 @@
 /** @jsxImportSource @emotion/react */
 import { memo } from 'react';
 import { coerceCssPixelValue } from './coerceCssPixelValue';
-import { ExtendHTMLProps } from './types';
+import { CSSPixelValue, ExtendHTMLProps } from './types';
 
 type SpacingProps = ExtendHTMLProps<
   HTMLDivElement,
   {
     children?: never;
     direction?: 'vertical' | 'horizontal';
-    size: string | number;
+    size: CSSPixelValue;
   }
 >;
 
@@ -19,7 +19,7 @@ type SpacingProps = ExtendHTMLProps<
  *   children?: never;
  *   // default: 'vertical'
  *   direction?: 'vertical' | 'horizontal';
- *   size: string | number;
+ *   size: CSSPixelValue;
  * }): JSX.Element;
  * ```
  *


### PR DESCRIPTION
## Overview

in emotion-utils 
they have type CSSPixelValue which is union type string and number
`type CSSPixelValue = string | number;`

Some file didn't use the CSSPixelValue in a specific part.
I thought this would undermine the unity of the project, so I improved it to use the defined type(CSSPixelValue).

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
