### PR TITLE
docs: fill in missing @description of zip

### DIFF
--- a/packages/common/utils/src/zip.ts
+++ b/packages/common/utils/src/zip.ts
@@ -3,7 +3,16 @@ type Zipped<T extends unknown[][]> = Array<{ [Key in keyof T]: ElementOf<T[Key]>
 
 /**
  * @name zip
+ * @description
  * Array의 zip 연산을 수행합니다.
+ *
+ * ```typescript
+ * zip<T extends unknown[][]>(
+ *   // zip 연산이 수행될 배열
+ *   ...arrays: [...T]
+ * ): Zipped<T>
+ * ```
+ *
  * @example
  * zip([1, 2], ['a', 'b']) --> [[1, 'a'], [2, 'b']]
  */


### PR DESCRIPTION
## Overview

util function `zip()`'s description is missing, so I filled `@description` and put some description for function.

```
/**
 * @name zip
 * @description
 * Array의 zip 연산을 수행합니다.
 *
 * ```typescript
 * zip<T extends unknown[][]>(
 *   // zip 연산이 수행될 배열
 *   ...arrays: [...T]
 * ): Zipped<T>
 * ```
 *
 * @example
 * zip([1, 2], ['a', 'b']) --> [[1, 'a'], [2, 'b']]
 */
```

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
