### PR TITLE
docs(w3c): refactor to validate w3c  

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
@@ -27,7 +27,7 @@ hide_table_of_contents: true
   </div>
 
   <div style={{ gridArea: 'image', textAlign: 'center' }}>
-  <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay="true" muted="true" playsInline="true" loop="true" />
+  <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay muted="true" playsInline="true" loop="true" />
   </div>
 </div>
 

--- a/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
@@ -10,31 +10,35 @@ hide_table_of_contents: true
   <meta property="og:description" content="높은 퀄리티의 웹 서비스를 개발하기 위한 TypeScript/JavaScript 패키지 세트" />
   <meta property="og:url" content="https://slash.page/ko" />
   <meta property="og:image" content="https://static.toss.im/assets/slash-libraries/slash-og.png" />
-  <style>
-    .mainpage_hero {
-       display: flex;
-    }
-    @media (min-width: 600px) {
+  <style
+    dangerouslySetInnerHTML={{
+      __html: `
       .mainpage_hero {
-        grid-template-areas: "text image";
-        grid-template-columns: 1fr 300px;
+        display: grid;
       }
-      .key-video {
-        width: 260px;
-        height: 146px;
+      @media (min-width: 600px) {
+        .mainpage_hero {
+          grid-template-areas: "text image";
+          grid-template-columns: 1fr 300px;
+          }
+        .key-video {
+          width: 260px;
+          height: 146px;
+          }
       }
-    }
-    @media (max-width: 600px) {
-      .mainpage_hero {
-        grid-template-areas: "image" "text";
-        grid-template-rows: min-content min-content;
+      @media (max-width: 600px) {
+        .mainpage_hero {
+          grid-template-areas: "image" "text";
+          grid-template-rows: min-content min-content;
+          }
+        .key-video {
+          width: 80%;
+          margin: 24px auto;
+          }
       }
-      .key-video {
-        width: 80%;
-        margin: 24px auto;
-      }
-    }
-  </style>
+  `,
+  }}
+  ></style>
 </head>
 
 <div className="mainpage_hero">

--- a/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
@@ -10,7 +10,7 @@ hide_table_of_contents: true
   <meta property="og:description" content="높은 퀄리티의 웹 서비스를 개발하기 위한 TypeScript/JavaScript 패키지 세트" />
   <meta property="og:url" content="https://slash.page/ko" />
   <meta property="og:image" content="https://static.toss.im/assets/slash-libraries/slash-og.png" />
-  <link href="../../../styles/index.css" rel="stylesheet">
+  <link href="../../../styles/index.css" rel="stylesheet"/>
 </head>
 
 <div className="mainpage_hero">

--- a/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
@@ -10,35 +10,7 @@ hide_table_of_contents: true
   <meta property="og:description" content="높은 퀄리티의 웹 서비스를 개발하기 위한 TypeScript/JavaScript 패키지 세트" />
   <meta property="og:url" content="https://slash.page/ko" />
   <meta property="og:image" content="https://static.toss.im/assets/slash-libraries/slash-og.png" />
-  <style
-    dangerouslySetInnerHTML={{
-      __html: `
-      .mainpage_hero {
-        display: grid;
-      }
-      @media (min-width: 600px) {
-        .mainpage_hero {
-          grid-template-areas: "text image";
-          grid-template-columns: 1fr 300px;
-          }
-        .key-video {
-          width: 260px;
-          height: 146px;
-          }
-      }
-      @media (max-width: 600px) {
-        .mainpage_hero {
-          grid-template-areas: "image" "text";
-          grid-template-rows: min-content min-content;
-          }
-        .key-video {
-          width: 80%;
-          margin: 24px auto;
-          }
-      }
-  `,
-  }}
-  ></style>
+  <link href="../../../styles/index.css" rel="stylesheet">
 </head>
 
 <div className="mainpage_hero">

--- a/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
@@ -10,6 +10,31 @@ hide_table_of_contents: true
   <meta property="og:description" content="높은 퀄리티의 웹 서비스를 개발하기 위한 TypeScript/JavaScript 패키지 세트" />
   <meta property="og:url" content="https://slash.page/ko" />
   <meta property="og:image" content="https://static.toss.im/assets/slash-libraries/slash-og.png" />
+  <style>
+    .mainpage_hero {
+       display: flex;
+    }
+    @media (min-width: 600px) {
+      .mainpage_hero {
+        grid-template-areas: "text image";
+        grid-template-columns: 1fr 300px;
+      }
+      .key-video {
+        width: 260px;
+        height: 146px;
+      }
+    }
+    @media (max-width: 600px) {
+      .mainpage_hero {
+        grid-template-areas: "image" "text";
+        grid-template-rows: min-content min-content;
+      }
+      .key-video {
+        width: 80%;
+        margin: 24px auto;
+      }
+    }
+  </style>
 </head>
 
 <div className="mainpage_hero">
@@ -30,40 +55,6 @@ hide_table_of_contents: true
   <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay muted="true" playsInline="true" loop="true" />
   </div>
 </div>
-
-<style
-  dangerouslySetInnerHTML={{
-    __html: `
-.mainpage_hero {
-  display: grid;
-}
-
-@media (min-width: 600px) {
-  .mainpage_hero {
-    grid-template-areas: "text image";
-    grid-template-columns: 1fr 300px;
-  }
-
-  .key-video {
-    width: 260px;
-    height: 146px;
-  }
-}
-
-@media (max-width: 600px) {
-  .mainpage_hero {
-    grid-template-areas: "image" "text";
-    grid-template-rows: min-content min-content;
-  }
-
-  .key-video {
-    width: 80%;
-    margin: 24px auto;
-  }
-}
-`,
-  }}
-></style>
 
 <div style={{ height: 24 }} />
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -30,7 +30,7 @@ hide_table_of_contents: true
   </div>
 
   <div style={{ gridArea: 'image', textAlign: 'center' }}>
-  <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay="true" muted="true" playsInline="true" loop="true" />
+  <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay muted="true" playsInline="true" loop="true" />
   </div>
 </div>
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -13,6 +13,31 @@ hide_table_of_contents: true
   />
   <meta property="og:url" content="https://slash.page" />
   <meta property="og:image" content="https://static.toss.im/assets/slash-libraries/slash-og.png" />
+  <style>
+    .mainpage_hero {
+       display: flex;
+    }
+    @media (min-width: 600px) {
+      .mainpage_hero {
+        grid-template-areas: "text image";
+        grid-template-columns: 1fr 300px;
+      }
+      .key-video {
+        width: 260px;
+        height: 146px;
+      }
+    }
+    @media (max-width: 600px) {
+      .mainpage_hero {
+        grid-template-areas: "image" "text";
+        grid-template-rows: min-content min-content;
+      }
+      .key-video {
+        width: 80%;
+        margin: 24px auto;
+      }
+    }
+  </style>
 </head>
 
 <div className="mainpage_hero">
@@ -33,40 +58,6 @@ hide_table_of_contents: true
   <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay muted="true" playsInline="true" loop="true" />
   </div>
 </div>
-
-<style
-  dangerouslySetInnerHTML={{
-    __html: `
-.mainpage_hero {
-  display: grid;
-}
-
-@media (min-width: 600px) {
-  .mainpage_hero {
-    grid-template-areas: "text image";
-    grid-template-columns: 1fr 300px;
-  }
-
-  .key-video {
-    width: 260px;
-    height: 146px;
-  }
-}
-
-@media (max-width: 600px) {
-  .mainpage_hero {
-    grid-template-areas: "image" "text";
-    grid-template-rows: min-content min-content;
-  }
-
-  .key-video {
-    width: 80%;
-    margin: 24px auto;
-  }
-}
-`,
-  }}
-></style>
 
 <div style={{ height: 24 }} />
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -13,35 +13,7 @@ hide_table_of_contents: true
   />
   <meta property="og:url" content="https://slash.page" />
   <meta property="og:image" content="https://static.toss.im/assets/slash-libraries/slash-og.png" />
-  <style
-    dangerouslySetInnerHTML={{
-      __html: `
-      .mainpage_hero {
-        display: grid;
-      }
-      @media (min-width: 600px) {
-        .mainpage_hero {
-          grid-template-areas: "text image";
-          grid-template-columns: 1fr 300px;
-          }
-        .key-video {
-          width: 260px;
-          height: 146px;
-          }
-      }
-      @media (max-width: 600px) {
-        .mainpage_hero {
-          grid-template-areas: "image" "text";
-          grid-template-rows: min-content min-content;
-          }
-        .key-video {
-          width: 80%;
-          margin: 24px auto;
-          }
-      }
-  `,
-  }}
-  ></style>
+  <link href="../styles/index.css" rel="stylesheet">
 </head>
 
 <div className="mainpage_hero">
@@ -59,7 +31,7 @@ hide_table_of_contents: true
   </div>
 
   <div style={{ gridArea: 'image', textAlign: 'center' }}>
-  <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay muted="true" playsInline="true" loop="true" />
+  <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay="true" muted="true" playsInline="true" loop="true" />
   </div>
 </div>
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -13,31 +13,35 @@ hide_table_of_contents: true
   />
   <meta property="og:url" content="https://slash.page" />
   <meta property="og:image" content="https://static.toss.im/assets/slash-libraries/slash-og.png" />
-  <style>
-    .mainpage_hero {
-       display: flex;
-    }
-    @media (min-width: 600px) {
+  <style
+    dangerouslySetInnerHTML={{
+      __html: `
       .mainpage_hero {
-        grid-template-areas: "text image";
-        grid-template-columns: 1fr 300px;
+        display: grid;
       }
-      .key-video {
-        width: 260px;
-        height: 146px;
+      @media (min-width: 600px) {
+        .mainpage_hero {
+          grid-template-areas: "text image";
+          grid-template-columns: 1fr 300px;
+          }
+        .key-video {
+          width: 260px;
+          height: 146px;
+          }
       }
-    }
-    @media (max-width: 600px) {
-      .mainpage_hero {
-        grid-template-areas: "image" "text";
-        grid-template-rows: min-content min-content;
+      @media (max-width: 600px) {
+        .mainpage_hero {
+          grid-template-areas: "image" "text";
+          grid-template-rows: min-content min-content;
+          }
+        .key-video {
+          width: 80%;
+          margin: 24px auto;
+          }
       }
-      .key-video {
-        width: 80%;
-        margin: 24px auto;
-      }
-    }
-  </style>
+  `,
+  }}
+  ></style>
 </head>
 
 <div className="mainpage_hero">

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -13,7 +13,7 @@ hide_table_of_contents: true
   />
   <meta property="og:url" content="https://slash.page" />
   <meta property="og:image" content="https://static.toss.im/assets/slash-libraries/slash-og.png" />
-  <link href="../styles/index.css" rel="stylesheet">
+  <link href="../styles/index.css" rel="stylesheet"/>
 </head>
 
 <div className="mainpage_hero">

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -1,0 +1,24 @@
+.mainpage_hero {
+  display: flex;
+}
+@media (min-width: 600px) {
+  .mainpage_hero {
+    grid-template-areas: 'text image';
+    grid-template-columns: 1fr 300px;
+  }
+  .key-video {
+    width: 260px;
+    height: 146px;
+  }
+}
+@media (max-width: 600px) {
+  .mainpage_hero {
+    grid-template-areas: 'image' 'text';
+    grid-template-rows: min-content min-content;
+  }
+
+  .key-video {
+    width: 80%;
+    margin: 24px auto;
+  }
+}


### PR DESCRIPTION
## Overview

When I verified the address https://slash.page/ where this library's document is currently deployed through w3c validator, I found that there were two errors.

[url of validation](https://validator.w3.org/nu/?doc=https%3A%2F%2Fslash.page%2F)
<img width="1377" alt="image" src="https://user-images.githubusercontent.com/69495129/195875530-9b915cff-eb7c-4347-a843-aee8db30f7a1.png">

so i fix two things to validate w3c.

---

1. I change autoplay="true" to just autoplay 

[mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Video)
>To disable video autoplay, autoplay="false" will not work; 
>the video will autoplay if the attribute is there in the <video> tag >at all. 

it says autoplay works just by writing autoplay itself not boolean value

---

2. I removed the style code from the inside of the article tag and put it inside the head.

If there is a reason why the developers put the style tag in the body area, I would appreciate it if you could explain it! I checked that it works well even if the style code is moved inside the head tag not in body part.

If this method is not good, I think there is a way to deploy the style code to CDN and then load it.

---

### Result

<img width="840" alt="image" src="https://user-images.githubusercontent.com/69495129/195876737-744ad0e7-3cf4-4b49-9e23-cd5d709dfc31.png">

Since I cannot deploy these docs and test them, I modified the tag directly in the html environment and went through the verification process in w3c. I've confirmed that it passed. This is considered to have followed the correct markup rules.



## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
4. I have written documents and tests, if needed.
