### PR TITLE
fix(emotion-utils): replace flex align type with CSSProperties['align…Items']

### DIFF
--- a/packages/react/emotion-utils/src/flex.tsx
+++ b/packages/react/emotion-utils/src/flex.tsx
@@ -38,12 +38,15 @@ export interface FlexOptions {
  */
 export function flex(options: FlexOptions): SerializedStyles;
 export function flex(
-  // NOTE(@noahluftyang): CSSProperties['alignItems']로 정의하면 union 타입이 잘 동작하지 않음
-  align: string,
+  align: CSSProperties['alignItems'],
   justify?: CSSProperties['justifyContent'],
   direction?: CSSProperties['flexDirection']
 ): SerializedStyles;
-export function flex(alignOrFlexOptions: FlexOptions | string, justify = 'flex-start', direction = 'row') {
+export function flex(
+  alignOrFlexOptions: FlexOptions | CSSProperties['alignItems'],
+  justify = 'flex-start',
+  direction = 'row'
+) {
   if (typeof alignOrFlexOptions === 'object') {
     const { align = 'stretch', direction = 'row', justify = 'flex-start' } = alignOrFlexOptions;
 


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->
 
1. Implementation of `flex` is slightly different from what is described in the JSDoc.
```ts
// in JSDoc
function flex(
  align?: CSSProperties['alignItems'],
  justify?: CSSProperties['justifyContent'],
  direction?: CSSProperties['flexDirection'],
): SerializedStyles;
```

// previous implementation
2. 

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
3. I have written documents and tests, if needed.
