### PR TITLE
fix(date): remove useless null check question mark in spec file

### DIFF
--- a/packages/common/date/src/date.spec.ts
+++ b/packages/common/date/src/date.spec.ts
@@ -1,12 +1,12 @@
-import { parseYYYYMMDD, getDateDistance, getDateDistanceText, TimeUnits } from './index';
+import { getDateDistance, getDateDistanceText, parseYYYYMMDD, TimeUnits } from './index';
 
 describe('parseYYYYMMDD', () => {
   test('"2020-04-23"은 2019년 4월 23일로 파싱한다.', () => {
     const date = parseYYYYMMDD('2020-04-23');
 
-    expect(date?.getFullYear()).toEqual(2020);
-    expect(date?.getMonth()).toEqual(3);
-    expect(date?.getDate()).toEqual(23);
+    expect(date.getFullYear()).toEqual(2020);
+    expect(date.getMonth()).toEqual(3);
+    expect(date.getDate()).toEqual(23);
   });
 
   test('"2020-13-02"는 에러를 던진다.', () => {

--- a/packages/common/date/src/date.spec.ts
+++ b/packages/common/date/src/date.spec.ts
@@ -10,19 +10,11 @@ describe('parseYYYYMMDD', () => {
   });
 
   test('"2020-13-02"는 에러를 던진다.', () => {
-    try {
-      parseYYYYMMDD('2020-13-02');
-    } catch (e: any) {
-      expect(e.message).toBe('Invalid date format');
-    }
+    expect(() => parseYYYYMMDD('2020-13-02')).toThrow('Invalid date format');
   });
 
   test('"2020-01-32"는 에러를 던진다.', () => {
-    try {
-      parseYYYYMMDD('2020-01-32');
-    } catch (e: any) {
-      expect(e.message).toBe('Invalid date format');
-    }
+    expect(() => parseYYYYMMDD('2020-01-32')).toThrow('Invalid date format');
   });
 });
 


### PR DESCRIPTION
## Overview

in date.spec.ts

```typescript
const date = parseYYYYMMDD('2020-04-23');
    expect(date.getFullYear()).toEqual(2020);
    expect(date.getMonth()).toEqual(3);
    expect(date.getDate()).toEqual(23);
```

date cannot be null because parseYYYYMMDD return only Date type anytime unless throw error
Therefore, if the value is returned, it is absolutely a Date type so question mark is useless!



## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
