### PR TITLE
docs(hangul): fix typos in disassembleHangul

### DIFF
--- a/packages/common/hangul/src/disassembleHangul.en.md
+++ b/packages/common/hangul/src/disassembleHangul.en.md
@@ -18,8 +18,8 @@ function disassembleHangul(
 ## Examples
 
 ```tsx
-disassembleHangulToGroups('값'); // 'ㄱㅏㅂㅅ'
-disassembleHangulToGroups('값이 비싸다'); // 'ㄱㅏㅂㅅㅇㅣ ㅂㅣㅆㅏㄷㅏ'
-disassembleHangulToGroups('ㅘ'); // 'ㅗㅏ'
-disassembleHangulToGroups('ㄵ'); // 'ㄴㅈ'
+disassembleHangul('값'); // 'ㄱㅏㅂㅅ'
+disassembleHangul('값이 비싸다'); // 'ㄱㅏㅂㅅㅇㅣ ㅂㅣㅆㅏㄷㅏ'
+disassembleHangul('ㅘ'); // 'ㅗㅏ'
+disassembleHangul('ㄵ'); // 'ㄴㅈ'
 ```

--- a/packages/common/hangul/src/disassembleHangul.ko.md
+++ b/packages/common/hangul/src/disassembleHangul.ko.md
@@ -18,8 +18,8 @@ function disassembleHangul(
 ## Examples
 
 ```tsx
-disassembleHangulToGroups('값'); // 'ㄱㅏㅂㅅ'
-disassembleHangulToGroups('값이 비싸다'); // 'ㄱㅏㅂㅅㅇㅣ ㅂㅣㅆㅏㄷㅏ'
-disassembleHangulToGroups('ㅘ'); // 'ㅗㅏ'
-disassembleHangulToGroups('ㄵ'); // 'ㄴㅈ'
+disassembleHangul('값'); // 'ㄱㅏㅂㅅ'
+disassembleHangul('값이 비싸다'); // 'ㄱㅏㅂㅅㅇㅣ ㅂㅣㅆㅏㄷㅏ'
+disassembleHangul('ㅘ'); // 'ㅗㅏ'
+disassembleHangul('ㄵ'); // 'ㄴㅈ'
 ```


### PR DESCRIPTION
## Overview
Thank you for making this awesome library public!
Reading @toss/hangul docs, I just came across a small typo.
Please review my suggestion for renaming the function.
`disassembleHangulToGroups()` ➜ `disassembleHangul()`



## PR Checklist

- [x] I read and included these actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests if needed.
