### PR TITLE
refactor(rollup): remove unused argument

### DIFF
--- a/configs/rollup/src/index.js
+++ b/configs/rollup/src/index.js
@@ -5,7 +5,7 @@ const json = require('@rollup/plugin-json');
 const resolve = require('@rollup/plugin-node-resolve').default;
 const builtins = require('builtin-modules');
 
-exports.generateRollupConfig = function generateRollupConfig({ packageDir, entrypoints: _entrypoints }) {
+exports.generateRollupConfig = function generateRollupConfig({ packageDir }) {
   const packageJSON = require(path.join(packageDir, 'package.json'));
 
   if (packageJSON.exports == null) {


### PR DESCRIPTION
## Overview
```javascript
// configs/rollup/src/index.js

exports.generateRollupConfig = function generateRollupConfig({ packageDir, entrypoints: _entrypoints }) { ... }
```

I deleted the unused `_entrypoints` from the `generateRollupConfig` function.  


Check please :D


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
