### PR TITLE
fix(storage): optimize function call in useIsomorphicLayoutEffect hook

### DIFF
--- a/packages/react/react/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/react/react/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,15 +1,15 @@
-import { isClient } from '@toss/utils';
+import { isServer } from '@toss/utils';
 import { useEffect, useLayoutEffect } from 'react';
 
 /**
  * @description
- * Client-side에서는 useLayoutEffect 방식을 쓰고, Server-side에서는 useEffect 방식을 쓰도록 하는 hook 입니다.
- *
  * Server-side에서는 useLayoutEffect 함수를 사용하면 warning 오류가 발생하기 때문에 사용하는 함수입니다.
+ *
+ * Client-side에서는 useLayoutEffect 방식을 쓰고, Server-side에서는 useEffect 방식을 쓰도록 하는 hook 입니다.
  *
  * @example
  * useIsomorphicLayoutEffect(() => {
  *   setSwipeRefreshEnabled(false);
  * }, []);
  */
-export const useIsomorphicLayoutEffect = isClient() ? useLayoutEffect : useEffect;
+export const useIsomorphicLayoutEffect = isServer() ? useEffect : useLayoutEffect;


### PR DESCRIPTION
## Overview


The `isServer` is being called within the `isClient` function, which thought an unnecessary function call was occurring once.
So I made the isServer function call directly from inside the useIsomorphicLayoutEffect hook.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
