### PR TITLE
docs: migrates jsdoc to i18n for @toss/error-boundary

### DIFF
--- a/packages/react/error-boundary/src/ErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.en.md
@@ -1,8 +1,5 @@
 # ErrorBoundary
 
-- see https://jbee.io/react/error-declarative-handling-1/ Declaratively handle loading and error conditions
-- see https://toss.im/slash-21/sessions/3-1 Suspense & error handling presentation in Slash 21
-
 Declaratively, the component used to manage errors.
 `ErrorBoundary` component catches errors in the render/useEffect and renders the given component with `renderFallback`
 

--- a/packages/react/error-boundary/src/ErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.en.md
@@ -1,0 +1,37 @@
+# ErrorBoundary
+
+- see https://jbee.io/react/error-declarative-handling-1/ Declaratively handle loading and error conditions
+- see https://toss.im/slash-21/sessions/3-1 Suspense & error handling presentation in Slash 21
+
+Declaratively, the component used to manage errors.
+`ErrorBoundary` component catches errors in the render/useEffect and renders the given component with `renderFallback`
+
+```typescript
+<ErrorBoundary
+  // Components to be rendered when an error occurs.
+  // The first parameter represents a caught error.
+  renderFallback={error => <div>error is occured. {error.message}</div>}
+  /*
+    Callback function to be called when an error occurs.
+    The first parameter represents the caught error, and the second parameter represents the stack of the
+    component where the error occurred.
+    Type of componentStack의 is `string`
+  */
+  onError={(error, { componentStack }) => {
+    alert(error.message);
+    console.log(componentStack);
+  }}
+  // If the value in the array changes, reset the error caught by ErrorBoundary.
+  // Verify that the values are the same with `Object.is()`.
+  // @default []
+  resetKeys={['key1', 'key2']}
+  // Called when the error is initialized.
+  // Type is `() => void`.
+  onReset={() => {}}
+  // Returns whether to ignore the caught error and throw again.
+  // If true is returned, do not catch the error from this ErrorBoundary and throw it.
+  ignoreError={error => error.message.includes('dummy')}
+>
+  <COMPONENT_CAN_CREATE_ERROR />
+</ErrorBoundary>
+```

--- a/packages/react/error-boundary/src/ErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.en.md
@@ -11,12 +11,11 @@ Declaratively, the component used to manage errors.
   // Components to be rendered when an error occurs.
   // The first parameter represents a caught error.
   renderFallback={error => <div>error is occured. {error.message}</div>}
-  /*
-    Callback function to be called when an error occurs.
-    The first parameter represents the caught error, and the second parameter represents the stack of the
-    component where the error occurred.
-    Type of componentStack의 is `string`
-  */
+
+  //  Callback function to be called when an error occurs.
+  //  The first parameter represents the caught error, and the second parameter represents the stack of the
+  //  component where the error occurred.
+  //  Type of componentStack의 is `string`
   onError={(error, { componentStack }) => {
     alert(error.message);
     console.log(componentStack);

--- a/packages/react/error-boundary/src/ErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.en.md
@@ -1,7 +1,7 @@
 # ErrorBoundary
 
-Declaratively, the component used to manage errors.
-`ErrorBoundary` component catches errors in the render/useEffect and renders the given component with `renderFallback`
+A component which is useful to manage an error declaratively.
+It catches the error occurred on render or in `useEffect` callback and then renders `renderFallback`.
 
 ```typescript
 <ErrorBoundary

--- a/packages/react/error-boundary/src/ErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.en.md
@@ -1,6 +1,7 @@
 # ErrorBoundary
 
 A component which is useful to manage an error declaratively.
+
 It catches the error occurred on render or in `useEffect` callback and then renders `renderFallback`.
 
 ```typescript

--- a/packages/react/error-boundary/src/ErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.en.md
@@ -11,11 +11,10 @@ Declaratively, the component used to manage errors.
   // Components to be rendered when an error occurs.
   // The first parameter represents a caught error.
   renderFallback={error => <div>error is occured. {error.message}</div>}
-
   //  Callback function to be called when an error occurs.
   //  The first parameter represents the caught error, and the second parameter represents the stack of the
   //  component where the error occurred.
-  //  Type of componentStack의 is `string`
+  //  Type of componentStack is `string`
   onError={(error, { componentStack }) => {
     alert(error.message);
     console.log(componentStack);

--- a/packages/react/error-boundary/src/ErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.ko.md
@@ -1,8 +1,5 @@
 # ErrorBoundary
 
-- see https://jbee.io/react/error-declarative-handling-1/ 선언적으로 로딩과 에러 상태 처리하기
-- see https://toss.im/slash-21/sessions/3-1 Suspense와 에러 처리 관련된 Slash 21 발표
-
 선언적으로 에러를 관리하기 위해서 사용하는 컴포넌트입니다.
 `ErrorBoundary` 컴포넌트는 children의 render/useEffect에서 발생한 에러를 잡아 `renderFallback`으로 주어진 컴포넌트를 렌더링합니다.
 
@@ -32,3 +29,8 @@
   <에러를_발생시킬_수_있는_컴포넌트 />
 </ErrorBoundary>
 ```
+
+## References
+
+- [React에서 선언적으로 비동기 다루기 - JBEE.io](https://jbee.io/react/error-declarative-handling-1/)
+- [프론트엔드 웹 서비스에서 우아하게 비동기 처리하기 - SLASH 21](https://toss.im/slash-21/sessions/3-1)

--- a/packages/react/error-boundary/src/ErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.ko.md
@@ -1,6 +1,7 @@
 # ErrorBoundary
 
 선언적으로 에러를 관리하기 위해서 사용하는 컴포넌트입니다.
+
 `ErrorBoundary` 컴포넌트는 children의 render/useEffect에서 발생한 에러를 잡아 `renderFallback`으로 주어진 컴포넌트를 렌더링합니다.
 
 ```typescript

--- a/packages/react/error-boundary/src/ErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/ErrorBoundary.ko.md
@@ -1,0 +1,34 @@
+# ErrorBoundary
+
+- see https://jbee.io/react/error-declarative-handling-1/ 선언적으로 로딩과 에러 상태 처리하기
+- see https://toss.im/slash-21/sessions/3-1 Suspense와 에러 처리 관련된 Slash 21 발표
+
+선언적으로 에러를 관리하기 위해서 사용하는 컴포넌트입니다.
+`ErrorBoundary` 컴포넌트는 children의 render/useEffect에서 발생한 에러를 잡아 `renderFallback`으로 주어진 컴포넌트를 렌더링합니다.
+
+```typescript
+<ErrorBoundary
+  // 에러가 발생하면 그려질 컴포넌트입니다.
+  // 첫 번째 인자는 잡힌 에러를 나타냅니다.
+  renderFallback={error => <div>에러가 발생했어요. {error.message}</div>}
+  // 에러가 발생하면 호출되는 callback입니다.
+  // 첫 번째 인자는 잡힌 에러, 두 번째 인자는 에러가 발생한 컴포넌트의 stack을 나타냅니다.
+  // componentStack의 타입은 `string` 입니다.
+  onError={(error, { componentStack }) => {
+    alert(error.message);
+    console.log(componentStack);
+  }}
+  // 배열 안에 담긴 값이 바뀌면 ErrorBoundary로 잡힌 에러를 초기화합니다.
+  // 값이 동일한지 여부는 `Object.is()` 로 검증합니다.
+  // @default []
+  resetKeys={['key1', 'key2']}
+  // 에러가 초기화되면 호출됩니다.
+  // 타입은 `() => void` 입니다.
+  onReset={() => {}}
+  // 잡힌 에러를 무시하고 다시 throw 할지 여부를 반환합니다.
+  // true 가 반환될 경우, error를 이 ErrorBoundary에서 잡지 않고 throw 합니다.
+  ignoreError={error => error.message.includes('어쩌구')}
+>
+  <에러를_발생시킬_수_있는_컴포넌트 />
+</ErrorBoundary>
+```

--- a/packages/react/error-boundary/src/ErrorBoundary.tsx
+++ b/packages/react/error-boundary/src/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+/** @tossdocs-ignore */
 import { isDifferentArray } from '@toss/utils';
 import { Component, ErrorInfo, PropsWithChildren, PropsWithRef, ReactNode } from 'react';
 

--- a/packages/react/error-boundary/src/ErrorBoundary.tsx
+++ b/packages/react/error-boundary/src/ErrorBoundary.tsx
@@ -31,44 +31,6 @@ interface State<ErrorType extends Error = Error> {
 const initialState: State = {
   error: null,
 };
-
-/**
- * @name ErrorBoundary
- * @description
- * 선언적으로 에러를 관리하기 위해서 사용하는 컴포넌트입니다.
- * `ErrorBoundary` 컴포넌트는 children의 render/useEffect에서 발생한 에러를 잡아 `renderFallback`으로 주어진 컴포넌트를 렌더링합니다.
- * @example
- * <ErrorBoundary
- *   // 에러가 발생하면 그려질 컴포넌트입니다.
- *   // 첫 번째 인자는 잡힌 에러를 나타냅니다.
- *   renderFallback={error => <div>에러가 발생했어요. {error.message}</div>}
- *
- *   // 에러가 발생하면 호출되는 callback입니다.
- *   // 첫 번째 인자는 잡힌 에러, 두 번째 인자는 에러가 발생한 컴포넌트의 stack을 나타냅니다.
- *   // componentStack의 타입은 `string` 입니다.
- *   onError={(error, { componentStack }) => {
- *     alert(error.message);
- *     console.log(componentStack);
- *   }}
- *
- *   // 배열 안에 담긴 값이 바뀌면 ErrorBoundary로 잡힌 에러를 초기화합니다.
- *   // 값이 동일한지 여부는 `Object.is()` 로 검증합니다.
- *   // @default []
- *   resetKeys={['key1', 'key2']}
- *
- *   // 에러가 초기화되면 호출됩니다.
- *   // 타입은 `() => void` 입니다.
- *   onReset={() => {}}
- *
- *   // 잡힌 에러를 무시하고 다시 throw 할지 여부를 반환합니다.
- *   // true 가 반환될 경우, error를 이 ErrorBoundary에서 잡지 않고 throw 합니다.
- *   ignoreError={error => error.message.includes('어쩌구')}
- * >
- *   <에러를_발생시킬_수_있는_컴포넌트 />
- * </ErrorBoundary>
- * @see https://jbee.io/react/error-declarative-handling-1/ 선언적으로 로딩과 에러 상태 처리하기
- * @see https://toss.im/slash-21/sessions/3-1 Suspense와 에러 처리 관련된 Slash 21 발표
- */
 export default class ErrorBoundary extends Component<PropsWithRef<PropsWithChildren<Props>>, State> {
   state = initialState;
   /**

--- a/packages/react/error-boundary/src/useErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.en.md
@@ -1,6 +1,7 @@
 # useErrorBoundary
 
 React's [`ErrorBoundary`](https://reactjs.org/docs/error-boundaries.html) component only catches an error occurred on render or in `useEffect` callback.
+
 So `useErrorBoundary` returns a function to deliver any error occurred in other place to `ErrorBoundary`.
 
 ```typescript

--- a/packages/react/error-boundary/src/useErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.en.md
@@ -1,0 +1,16 @@
+# useErrorBoundary
+
+Hook used to deliver the error to the nearest `ErrorBoundary`.
+
+```typescript
+const throwError = useErrorBoundary();
+
+<Button
+  onClick={() => {
+    if (someCondition) {
+      // This parameter will be showed in ErrorBoundary
+      throwError(new Error('throw error'));
+    }
+  }}
+/>;
+```

--- a/packages/react/error-boundary/src/useErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.en.md
@@ -2,6 +2,9 @@
 
 Hook used to deliver the error to the nearest `ErrorBoundary`.
 
+React's [`ErrorBoundary`](https://reactjs.org/docs/error-boundaries.html) component only catches an error occurred on render or in `useEffect` callback.
+So `useErrorBoundary` returns a function to deliver any error occurred in other place to `ErrorBoundary`.
+
 ```typescript
 const throwError = useErrorBoundary();
 

--- a/packages/react/error-boundary/src/useErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.en.md
@@ -1,7 +1,5 @@
 # useErrorBoundary
 
-Hook used to deliver the error to the nearest `ErrorBoundary`.
-
 React's [`ErrorBoundary`](https://reactjs.org/docs/error-boundaries.html) component only catches an error occurred on render or in `useEffect` callback.
 So `useErrorBoundary` returns a function to deliver any error occurred in other place to `ErrorBoundary`.
 

--- a/packages/react/error-boundary/src/useErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.en.md
@@ -1,8 +1,8 @@
 # useErrorBoundary
 
-React's [`ErrorBoundary`](https://reactjs.org/docs/error-boundaries.html) component only catches an error occurred on render or in `useEffect` callback.
+React's [error boundary](https://reactjs.org/docs/error-boundaries.html) component cannot catch an error occurred in event handlers, asynchronous code like `setTimeout`, etc.
 
-So `useErrorBoundary` returns a function to deliver any error occurred in other place to `ErrorBoundary`.
+`useErrorBoundary` is useful to deliver an error to the nearest error boundary in anywhere.
 
 ```typescript
 const throwError = useErrorBoundary();

--- a/packages/react/error-boundary/src/useErrorBoundary.en.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.en.md
@@ -8,7 +8,7 @@ const throwError = useErrorBoundary();
 <Button
   onClick={() => {
     if (someCondition) {
-      // This parameter will be showed in ErrorBoundary
+      // Throws `new Error('throw error')` to the nearest `ErrorBoundary`.
       throwError(new Error('throw error'));
     }
   }}

--- a/packages/react/error-boundary/src/useErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.ko.md
@@ -1,6 +1,7 @@
 # useErrorBoundary
 
 리액트에서 제공해주는 [`ErrorBoundary`](https://ko.reactjs.org/docs/error-boundaries.html#gatsby-focus-wrapper)는 랜더링 및 `useEffect` 의 콜백함수 내에서 오류가 발생했을때에만 에러를 인지합니다.
+
 `useErrorBoundary`를 사용하여 다른 경우에 발생한 에러를 ErrorBoundary에게 전달해줄 수 있습니다.
 
 ```typescript

--- a/packages/react/error-boundary/src/useErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.ko.md
@@ -1,8 +1,8 @@
 # useErrorBoundary
 
-리액트에서 제공해주는 [`ErrorBoundary`](https://ko.reactjs.org/docs/error-boundaries.html#gatsby-focus-wrapper)는 랜더링 및 `useEffect` 의 콜백함수 내에서 오류가 발생했을때에만 에러를 인지합니다.
+리액트의 [`Error Boundary`](https://ko.reactjs.org/docs/error-boundaries.html)는 이벤트 핸들러 등에서 발생한 에러는 인지하지 못합니다.
 
-`useErrorBoundary`를 사용하여 다른 경우에 발생한 에러를 ErrorBoundary에게 전달해줄 수 있습니다.
+`useErrorBoundary`를 사용하면 Error Boundary가 인지하지 못하는 에러를 전달해줄 수 있습니다.
 
 ```typescript
 const throwError = useErrorBoundary();

--- a/packages/react/error-boundary/src/useErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.ko.md
@@ -1,6 +1,5 @@
 # useErrorBoundary
 
-가장 가까운 `ErrorBoundary` 에 에러를 전달하기 위해 사용하는 Hook 입니다.
 리액트에서 제공해주는 [`ErrorBoundary`](https://ko.reactjs.org/docs/error-boundaries.html#gatsby-focus-wrapper)는 랜더링 및 `useEffect` 의 콜백함수 내에서 오류가 발생했을때에만 에러를 인지합니다.
 `useErrorBoundary`를 사용하여 다른 경우에 발생한 에러를 ErrorBoundary에게 전달해줄 수 있습니다.
 

--- a/packages/react/error-boundary/src/useErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.ko.md
@@ -8,7 +8,7 @@ const throwError = useErrorBoundary();
 <Button
   onClick={() => {
     if (someCondition) {
-      // 가장 가까운 ErrorBoundary에 인자로 넘겨주는 에러를 보여줍니다.
+      // 가장 가까운 ErrorBoundary로 new Error('에러 발생')이 throw됩니다.
       throwError(new Error('에러 발생'));
     }
   }}

--- a/packages/react/error-boundary/src/useErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.ko.md
@@ -1,0 +1,16 @@
+# useErrorBoundary
+
+가장 가까운 `ErrorBoundary` 에 에러를 전달하기 위해 사용하는 Hook 입니다.
+
+```typescript
+const throwError = useErrorBoundary();
+
+<Button
+  onClick={() => {
+    if (someCondition) {
+      // 가장 가까운 ErrorBoundary에 인자로 넘겨주는 에러를 보여줍니다.
+      throwError(new Error('에러 발생'));
+    }
+  }}
+/>;
+```

--- a/packages/react/error-boundary/src/useErrorBoundary.ko.md
+++ b/packages/react/error-boundary/src/useErrorBoundary.ko.md
@@ -1,6 +1,8 @@
 # useErrorBoundary
 
 가장 가까운 `ErrorBoundary` 에 에러를 전달하기 위해 사용하는 Hook 입니다.
+리액트에서 제공해주는 [`ErrorBoundary`](https://ko.reactjs.org/docs/error-boundaries.html#gatsby-focus-wrapper)는 랜더링 및 `useEffect` 의 콜백함수 내에서 오류가 발생했을때에만 에러를 인지합니다.
+`useErrorBoundary`를 사용하여 다른 경우에 발생한 에러를 ErrorBoundary에게 전달해줄 수 있습니다.
 
 ```typescript
 const throwError = useErrorBoundary();

--- a/packages/react/error-boundary/src/useErrorBoundary.ts
+++ b/packages/react/error-boundary/src/useErrorBoundary.ts
@@ -1,22 +1,6 @@
+/** @tossdocs-ignore */
 import { useState } from 'react';
 
-/**
- * @name useErrorBoundary
- * @description
- * 가장 가까운 `ErrorBoundary` 에 에러를 전달하기 위해 사용하는 Hook 입니다.
- * ```typescript
- * const throwError = useErrorBoundary();
- *
- * <Button
- *   onClick={() => {
- *     if (someCondition) {
- *       // 가장 가까운 ErrorBoundary에 인자로 넘겨주는 에러를 보여줍니다.
- *       throwError(new Error('에러 발생'));
- *     }
- *   }}
- * />
- * ```
- */
 export default function useErrorBoundary<ErrorType extends Error>() {
   const [error, setError] = useState<ErrorType | null>(null);
 


### PR DESCRIPTION
## Overview

I translated the package to make it easier for others to use @toss/error-boundary, which helps them manage errors declaratively.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
