### PR TITLE
fix(utils): fix incorrect example in docs & add test code

### DIFF
--- a/packages/common/utils/src/Numbers.spec.ts
+++ b/packages/common/utils/src/Numbers.spec.ts
@@ -40,7 +40,7 @@ describe('Numbers', () => {
 
   test('decommaizeNumber', () => {
     expect(decommaizeNumber('13,209,802')).toEqual(13209802);
-    expect(decommaizeNumber('1234,1,,234')).toEqual(12341234);
+    expect(decommaizeNumber('12,341,234')).toEqual(12341234);
   });
 
   test('formatToKoreanNumber', () => {

--- a/packages/common/utils/src/Numbers.spec.ts
+++ b/packages/common/utils/src/Numbers.spec.ts
@@ -1,6 +1,7 @@
 import {
   ceilToUnit,
   commaizeNumber,
+  decommaizeNumber,
   floorToUnit,
   formatBusinessRegistrationNumber,
   formatPhoneNumber,
@@ -35,6 +36,11 @@ describe('Numbers', () => {
     expect(commaizeNumber('1234.1234')).toEqual('1,234.1234');
     expect(commaizeNumber('100')).toEqual('100');
     expect(commaizeNumber('100000000')).toEqual('100,000,000');
+  });
+
+  test('decommaizeNumber', () => {
+    expect(decommaizeNumber('13,209,802')).toEqual(13209802);
+    expect(decommaizeNumber('1234,1,,234')).toEqual(12341234);
   });
 
   test('formatToKoreanNumber', () => {

--- a/packages/common/utils/src/Numbers_decommaize.en.md
+++ b/packages/common/utils/src/Numbers_decommaize.en.md
@@ -14,6 +14,5 @@ function decommaizeNumber(numStr: string): number;
 ## Example
 
 ```typescript
-decommaizeNumber(13209802); // '13,209,802'
-decommaizeNumber('13209802'); // '13,209,802'
+decommaizeNumber('13,209,802'); // 13209802
 ```

--- a/packages/common/utils/src/Numbers_decommaize.ko.md
+++ b/packages/common/utils/src/Numbers_decommaize.ko.md
@@ -14,6 +14,5 @@ function decommaizeNumber(numStr: string): number;
 ## Example
 
 ```typescript
-decommaizeNumber(13209802); // => '13,209,802'
-decommaizeNumber('13209802'); // => '13,209,802'
+decommaizeNumber('13,209,802'); // 13209802
 ```


### PR DESCRIPTION
## Overview

- Docs example for decommaizeNumber was given as an example for commaizeNumber. 
  - [fix: @toss/utils decommaizeNumber docs](https://github.com/toss/slash/commit/1e5d1f716d5e1943dcf6f900bc80a2d9775cc1bc)
- There are no test codes created for decommaizeNumber, so I wrote some.
  -   [feat: @toss/utils write decommaizeNumber test code](https://github.com/toss/slash/commit/e7c04c1abb1b8599d96dd99349e123112394fb12)


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
