### PR TITLE
feat(emotion-utils): Add position's function method(absolute, fixed, sticky)

### DIFF
--- a/packages/react/emotion-utils/src/utils/position.test.tsx
+++ b/packages/react/emotion-utils/src/utils/position.test.tsx
@@ -47,7 +47,7 @@ describe('position 테스트', () => {
     expect(el).toHaveStyleRule('left', '0');
   });
 
-  describe('position 메서드', () => {
+  describe('position methods', () => {
     describe('absolute', () => {
       it('position.absolute({top: 0, left: 0})', () => {
         const { getByTestId } = render(<div data-testid="test" css={position.absolute({ top: 0, left: 0 })} />);

--- a/packages/react/emotion-utils/src/utils/position.test.tsx
+++ b/packages/react/emotion-utils/src/utils/position.test.tsx
@@ -46,4 +46,96 @@ describe('position 테스트', () => {
     expect(el).not.toHaveStyleRule('right', '0');
     expect(el).toHaveStyleRule('left', '0');
   });
+
+  describe('position 메서드', () => {
+    describe('absolute', () => {
+      it('position.absolute({top: 0, left: 0})', () => {
+        const { getByTestId } = render(<div data-testid="test" css={position.absolute({ top: 0, left: 0 })} />);
+
+        const el = getByTestId('test');
+
+        expect(el).toBeInTheDocument();
+
+        expect(el).toHaveStyleRule('position', 'absolute');
+        expect(el).toHaveStyleRule('top', '0');
+        expect(el).not.toHaveStyleRule('bottom', '0');
+        expect(el).not.toHaveStyleRule('right', '0');
+        expect(el).toHaveStyleRule('left', '0');
+      });
+
+      it('position.absolute(0, 0, 0, 0)', () => {
+        const { getByTestId } = render(<div data-testid="test" css={position.absolute(0, 0, 0, 0)} />);
+
+        const el = getByTestId('test');
+
+        expect(el).toBeInTheDocument();
+
+        expect(el).toHaveStyleRule('position', 'absolute');
+        expect(el).toHaveStyleRule('top', '0');
+        expect(el).toHaveStyleRule('bottom', '0');
+        expect(el).toHaveStyleRule('right', '0');
+        expect(el).toHaveStyleRule('left', '0');
+      });
+    });
+
+    describe('fixed', () => {
+      it('position.fixed({top: 0, left: 0})', () => {
+        const { getByTestId } = render(<div data-testid="test" css={position.fixed({ top: 0, left: 0 })} />);
+
+        const el = getByTestId('test');
+
+        expect(el).toBeInTheDocument();
+
+        expect(el).toHaveStyleRule('position', 'fixed');
+        expect(el).toHaveStyleRule('top', '0');
+        expect(el).not.toHaveStyleRule('bottom', '0');
+        expect(el).not.toHaveStyleRule('right', '0');
+        expect(el).toHaveStyleRule('left', '0');
+      });
+
+      it('position.fixed(0, 0, 0, 0)', () => {
+        const { getByTestId } = render(<div data-testid="test" css={position.fixed(0, 0, 0, 0)} />);
+
+        const el = getByTestId('test');
+
+        expect(el).toBeInTheDocument();
+
+        expect(el).toHaveStyleRule('position', 'fixed');
+        expect(el).toHaveStyleRule('top', '0');
+        expect(el).toHaveStyleRule('bottom', '0');
+        expect(el).toHaveStyleRule('right', '0');
+        expect(el).toHaveStyleRule('left', '0');
+      });
+    });
+
+    describe('sticky', () => {
+      it('position.sticky({top: 0, left: 0})', () => {
+        const { getByTestId } = render(<div data-testid="test" css={position.sticky({ top: 0, left: 0 })} />);
+
+        const el = getByTestId('test');
+
+        expect(el).toBeInTheDocument();
+
+        expect(el).toHaveStyleRule('position', 'sticky');
+        expect(el).toHaveStyleRule('top', '0');
+        expect(el).not.toHaveStyleRule('bottom', '0');
+        expect(el).not.toHaveStyleRule('right', '0');
+        expect(el).toHaveStyleRule('left', '0');
+      });
+
+      it('position.sticky(0, 0, 0, 0)', () => {
+        const { getByTestId } = render(<div data-testid="test" css={position.sticky(0, 0, 0, 0)} />);
+
+        const el = getByTestId('test');
+
+        expect(el).toBeInTheDocument();
+
+        expect(el).toHaveStyleRule('position', 'sticky');
+        expect(el).toHaveStyleRule('top', '0');
+        expect(el).toHaveStyleRule('bottom', '0');
+        expect(el).toHaveStyleRule('right', '0');
+        expect(el).toHaveStyleRule('left', '0');
+      });
+    });
+  });
 });

--- a/packages/react/emotion-utils/src/utils/position.ts
+++ b/packages/react/emotion-utils/src/utils/position.ts
@@ -52,6 +52,10 @@ interface Coordinates {
  *
  * // 다음처럼도 사용 가능합니다
  * position('absolute', {top: 0, left: 0});
+ *
+ * // 다음처럼도 사용 가능합니다(absolute, fixed, sticky)
+ * position.absolute(0, 0, 0, ,0);
+ * position.absolute({top: 0, left: 0});
  */
 export function position(
   position: Property.Position,
@@ -103,4 +107,46 @@ function isPositionValue(value: unknown): value is Property.Position {
 
 function isCSSPixelValue(value: unknown): value is CSSPixelValue {
   return typeof value === 'string' || typeof value === 'number';
+}
+
+position.absolute = absolute;
+position.fixed = fixed;
+position.sticky = sticky;
+
+function absolute(coordinates: Coordinates): SerializedStyles;
+function absolute(
+  top: CSSPixelValue,
+  right: CSSPixelValue,
+  bottom: CSSPixelValue,
+  left: CSSPixelValue
+): SerializedStyles;
+function absolute(topOrCoordinates: Coordinates | CSSPixelValue, ...values: CSSPixelValue[]) {
+  // position(position, coordinates);
+  if (!isCSSPixelValue(topOrCoordinates)) {
+    return position('absolute', topOrCoordinates);
+  }
+  // position(position, top, right, bottom, left);
+  return position('absolute', topOrCoordinates, values[0], values[1], values[2]);
+}
+
+function fixed(coordinates: Coordinates): SerializedStyles;
+function fixed(top: CSSPixelValue, right: CSSPixelValue, bottom: CSSPixelValue, left: CSSPixelValue): SerializedStyles;
+function fixed(topOrCoordinates: Coordinates | CSSPixelValue, ...values: CSSPixelValue[]) {
+  // position(position, coordinates);
+  if (!isCSSPixelValue(topOrCoordinates)) {
+    return position('fixed', topOrCoordinates);
+  }
+  // position(position, top, right, bottom, left);
+  return position('fixed', topOrCoordinates, values[0], values[1], values[2]);
+}
+
+function sticky(coordinates: Coordinates): SerializedStyles;
+function sticky(top: CSSPixelValue, right: CSSPixelValue, bottom: CSSPixelValue, left: CSSPixelValue): SerializedStyles;
+function sticky(topOrCoordinates: Coordinates | CSSPixelValue, ...values: CSSPixelValue[]) {
+  // position(position, coordinates);
+  if (!isCSSPixelValue(topOrCoordinates)) {
+    return position('sticky', topOrCoordinates);
+  }
+  // position(position, top, right, bottom, left);
+  return position('sticky', topOrCoordinates, values[0], values[1], values[2]);
 }

--- a/packages/react/emotion-utils/src/utils/position.ts
+++ b/packages/react/emotion-utils/src/utils/position.ts
@@ -109,44 +109,21 @@ function isCSSPixelValue(value: unknown): value is CSSPixelValue {
   return typeof value === 'string' || typeof value === 'number';
 }
 
-position.absolute = absolute;
-position.fixed = fixed;
-position.sticky = sticky;
+position.absolute = createPosition('absolute');
+position.fixed = createPosition('fixed');
+position.sticky = createPosition('sticky');
 
-function absolute(coordinates: Coordinates): SerializedStyles;
-function absolute(
-  top: CSSPixelValue,
-  right: CSSPixelValue,
-  bottom: CSSPixelValue,
-  left: CSSPixelValue
-): SerializedStyles;
-function absolute(topOrCoordinates: Coordinates | CSSPixelValue, ...values: CSSPixelValue[]) {
-  // position(position, coordinates);
-  if (!isCSSPixelValue(topOrCoordinates)) {
-    return position('absolute', topOrCoordinates);
+function createPosition(pos: Property.Position) {
+  function func(coordinates: Coordinates): SerializedStyles;
+  function func(top: CSSPixelValue, right: CSSPixelValue, bottom: CSSPixelValue, left: CSSPixelValue): SerializedStyles;
+  function func(topOrCoordinates: Coordinates | CSSPixelValue, ...values: CSSPixelValue[]) {
+    // position(position, coordinates);
+    if (!isCSSPixelValue(topOrCoordinates)) {
+      return position(pos, topOrCoordinates);
+    }
+    // position(position, top, right, bottom, left);
+    return position(pos, topOrCoordinates, values[0], values[1], values[2]);
   }
-  // position(position, top, right, bottom, left);
-  return position('absolute', topOrCoordinates, values[0], values[1], values[2]);
-}
 
-function fixed(coordinates: Coordinates): SerializedStyles;
-function fixed(top: CSSPixelValue, right: CSSPixelValue, bottom: CSSPixelValue, left: CSSPixelValue): SerializedStyles;
-function fixed(topOrCoordinates: Coordinates | CSSPixelValue, ...values: CSSPixelValue[]) {
-  // position(position, coordinates);
-  if (!isCSSPixelValue(topOrCoordinates)) {
-    return position('fixed', topOrCoordinates);
-  }
-  // position(position, top, right, bottom, left);
-  return position('fixed', topOrCoordinates, values[0], values[1], values[2]);
-}
-
-function sticky(coordinates: Coordinates): SerializedStyles;
-function sticky(top: CSSPixelValue, right: CSSPixelValue, bottom: CSSPixelValue, left: CSSPixelValue): SerializedStyles;
-function sticky(topOrCoordinates: Coordinates | CSSPixelValue, ...values: CSSPixelValue[]) {
-  // position(position, coordinates);
-  if (!isCSSPixelValue(topOrCoordinates)) {
-    return position('sticky', topOrCoordinates);
-  }
-  // position(position, top, right, bottom, left);
-  return position('sticky', topOrCoordinates, values[0], values[1], values[2]);
+  return func;
 }


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

- Add position's function method(absolute, fixed, sticky)
```
position.absolute({ top: 0, left: 0 });
position.absolute(0, 0, 0, 0);
```
- Add example code as comments
- Add test case
- Duplicate code exists. I tried several ways but failed. Please let me know if there is a better way
- cc https://github.com/toss/slash/issues/100

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
