### PR TITLE
docs: Fix incorrect address in @toss/react

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -73,7 +73,7 @@ hide_table_of_contents: true
 ## Featured libraries
 
 - [**@toss/use-overlay**](https://slash.page/libraries/react/use-overlay/src/useOverlay.i18n) provides the `useOverlay` React hook to control overlays in a declarative way.
-- [**@toss/react**](https://slash.page/libraries/react/react/src/components/ClickArea/ClickArea.tsx.tossdocs) provides several React components and hooks to develop high-quality web services.
+- [**@toss/react**](https://slash.page/libraries/react/react/src/components/ClickArea/ClickArea.i18n) provides several React components and hooks to develop high-quality web services.
 - [**@toss/utils**](https://slash.page/libraries/common/utils/README.i18n) provides simple and modern helper libraries which can be used both in Node.js and browser environments.
 - [**@toss/hangul**](https://slash.page/libraries/common/hangul/README.i18n) provides utility functions to manipulate [hangul](https://en.wikipedia.org/wiki/Hangul) characters.
 


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

The @toss/react page appears as not found.
The link address is invalid, so I fixed it with the correct link.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
