### PR TITLE
ci: Remove unnecessary git setup step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,15 +21,6 @@ commands:
 
             corepack enable --install-directory $COREPACK_PATH
             yarn install --immutable --immutable-cache
-      - run:
-          name: Setup git
-          command: |
-            export GITHUB_TOKEN="$GITHUB_TOKEN"
-            git remote set-url origin https://${GITHUB_TOKEN}@github.com/toss/slash.git
-            git fetch --all --tags
-            git fetch --force --progress -- origin +refs/heads/main:refs/remotes/origin/main
-            git config user.email "frontend.chapter@toss.im"
-            git config user.name "Toss Frontend Chapter"
   export_published_version:
     description: Export Published Version Environment Variable
     steps:
@@ -191,39 +182,29 @@ workflows:
     jobs:
       - test:
           context:
-            - github-com-fe
             - npm-public
           filters:
             branches:
               ignore: main
       - test-all:
           context:
-            - github-com-fe
             - npm-public
           filters:
             branches:
               only: main
       - lint:
-          context:
-            - github-com-fe
           filters:
             branches:
               ignore: main
       - typecheck:
-          context:
-            - github-com-fe
           filters:
             branches:
               ignore: main
       - pre-pack:
-          context:
-            - github-com-fe
           filters:
             branches:
               ignore: main
       - check-peer:
-          context:
-            - github-com-fe
           filters:
             branches:
               ignore: main


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

There is a legacy git setup step in our CI config, making forked pull requests not built. Removed this step to make forked PRs to be checked correctly.

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
