### PR TITLE
fix(lottie): Preserves references of event handler props for Lottie

### DIFF
--- a/packages/react/lottie/src/Lottie.tsx
+++ b/packages/react/lottie/src/Lottie.tsx
@@ -1,6 +1,7 @@
 /** @tossdocs-ignore */
 import { ImpressionArea } from '@toss/impression-area';
-import { useBooleanState, useCombinedRefs } from '@toss/react';
+import { useBooleanState, useCombinedRefs, usePreservedCallback } from '@toss/react';
+import { noop } from '@toss/utils';
 import { forwardRef, Ref, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { AnimationChain } from './AnimationChain';
 import { LoopType } from './AnimationPlayer';
@@ -56,12 +57,16 @@ export const Lottie = forwardRef(function Lottie(
     width,
     height,
     alt,
-    onPlay,
-    onLoopComplete,
-    onComplete,
+    onPlay: _onPlay,
+    onLoopComplete: _onLoopComplete,
+    onComplete: _onComplete,
   }: Props,
   lottieRef: Ref<LottieRef>
 ) {
+  const onPlay = usePreservedCallback(_onPlay ?? noop);
+  const onLoopComplete = usePreservedCallback(_onLoopComplete ?? noop);
+  const onComplete = usePreservedCallback(_onComplete ?? noop);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const animationChainRef = useRef<AnimationChain | null>(null);
 
@@ -80,8 +85,8 @@ export const Lottie = forwardRef(function Lottie(
       typeof json === 'string'
         ? [{ json, assets }]
         : typeof src === 'string'
-        ? [{ url: src, assets }]
-        : src!.map(url => ({ url, assets }));
+          ? [{ url: src, assets }]
+          : src!.map(url => ({ url, assets }));
 
     const chain = AnimationChain(animationData, {
       loop,


### PR DESCRIPTION
## Overview

- `startAnimation` is called in `useEffect`, but it depends on `onPlay` prop.
- So if the reference of `onPlay` was changed, `startAnimation` would be changed too and then be called again.
    - Users can see the animation from the beginning on every render.
- So I wrapped all event handler props by `usePreservedCallback`.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
