### PR TITLE
docs(react): IntervalOptions typo

### DIFF
--- a/packages/react/react/src/hooks/useInterval.ts
+++ b/packages/react/react/src/hooks/useInterval.ts
@@ -12,7 +12,7 @@ type IntervalOptions =
  * window.setInterval 를 쉽게 사용할 수 있는 hook 입니다.
  *
  * ```ts
- * // number 혹은 InvervalOptions를 입력해주세요
+ * // number 혹은 IntervalOptions를 입력해주세요
  * type IntervalOptions =
  *   | number
  *   | {


### PR DESCRIPTION
## Overview

I change InvervalOptions to IntervalOptions which is typo I think!

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
