### PR TITLE
feat(utils): add omit

### DIFF
--- a/packages/common/utils/src/object/index.ts
+++ b/packages/common/utils/src/object/index.ts
@@ -2,3 +2,4 @@
 export * from './object-entries';
 export * from './object-keys';
 export * from './object-values';
+export * from './omit';

--- a/packages/common/utils/src/object/omit.en.md
+++ b/packages/common/utils/src/object/omit.en.md
@@ -1,0 +1,21 @@
+---
+hide_title: true
+sidebar_label: omit
+---
+
+# omit
+
+A utility function to construct new object by removing the key-value pairs corresponding to the given keys from the object.
+
+## Example
+
+```typescript
+const country = {
+    KR: 'KR',
+    US: 'US',
+    JP: 'JP',
+} as const;
+
+omit(country, ['CA']); //  TS2322: Type '"CA"' is not assignable to type '"KR" | "US" | "JP"'
+omit(country, ['KR']); //  Omit<{readonly KR: "KR", readonly US: "US", readonly JP: "JP"}, "KR">
+```

--- a/packages/common/utils/src/object/omit.ko.md
+++ b/packages/common/utils/src/object/omit.ko.md
@@ -1,0 +1,21 @@
+---
+hide_title: true
+sidebar_label: omit
+---
+
+# omit
+
+객체에서 주어진 키들에 해당하는 키-값 쌍들을 제거하여 새로운 객체를 만드는 유틸입니다.
+
+## Example
+
+```typescript
+const country = {
+    KR: 'KR',
+    US: 'US',
+    JP: 'JP',
+} as const;
+
+omit(country, ['CA']); //  TS2322: Type '"CA"' is not assignable to type '"KR" | "US" | "JP"'
+omit(country, ['KR']); //  Omit<{readonly KR: "KR", readonly US: "US", readonly JP: "JP"}, "KR">
+```

--- a/packages/common/utils/src/object/omit.ts
+++ b/packages/common/utils/src/object/omit.ts
@@ -1,0 +1,13 @@
+import {ObjectKeys, objectKeys} from "./object-keys";
+
+type ArrayUnion<Type extends readonly unknown[]> = Type[number];
+
+export function omit<ObjectType extends Record<PropertyKey, unknown>, KeyTypes extends Array<ObjectKeys<ObjectType>>>(
+    obj: ObjectType,
+    keys: KeyTypes,
+) {
+    return objectKeys(obj)
+        .filter((k): k is Exclude<ObjectKeys<ObjectType>, ArrayUnion<KeyTypes>> => !keys.includes(k))
+        .reduce((acc, key) => ((acc[key] = obj[key]), acc), {} as Omit<ObjectType, ArrayUnion<KeyTypes>>);
+}
+


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

added utility function `omit`;
constructs new object by removing the key-value pairs corresponding to the given keys from the object. (omitted type is inferred)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
