### PR TITLE
fix(use-overlay): remove unused props

### DIFF
--- a/packages/react/use-overlay/src/OverlayProvider.tsx
+++ b/packages/react/use-overlay/src/OverlayProvider.tsx
@@ -9,7 +9,7 @@ if (process.env.NODE_ENV !== 'production') {
   OverlayContext.displayName = 'OverlayContext';
 }
 
-export function OverlayProvider({ children }: PropsWithChildren<{ containerId?: string }>) {
+export function OverlayProvider({ children }: PropsWithChildren) {
   const [overlayById, setOverlayById] = useState<Map<string, ReactNode>>(new Map());
 
   const mount = useCallback((id: string, element: ReactNode) => {

--- a/packages/react/use-overlay/src/useOverlay.tsx
+++ b/packages/react/use-overlay/src/useOverlay.tsx
@@ -14,7 +14,7 @@ export function useOverlay({ exitOnUnmount = true }: Options = {}) {
   const context = useContext(OverlayContext);
 
   if (context == null) {
-    throw new Error('useOverlay는 OverlayProvider 안에서만 사용 가능합니다.');
+    throw new Error('useOverlay is only available within OverlayProvider.');
   }
 
   const { mount, unmount } = context;

--- a/packages/react/use-overlay/src/useOverlay.tsx
+++ b/packages/react/use-overlay/src/useOverlay.tsx
@@ -36,7 +36,7 @@ export function useOverlay({ exitOnUnmount = true }: Options = {}) {
         mount(
           id,
           <OverlayController
-            key={id}
+            key={Date.now()}
             ref={overlayRef}
             overlayElement={overlayElement}
             onExit={() => {

--- a/packages/react/use-overlay/src/useOverlay.tsx
+++ b/packages/react/use-overlay/src/useOverlay.tsx
@@ -36,6 +36,7 @@ export function useOverlay({ exitOnUnmount = true }: Options = {}) {
         mount(
           id,
           <OverlayController
+            // NOTE: state should be reset every time we open an overlay
             key={Date.now()}
             ref={overlayRef}
             overlayElement={overlayElement}

--- a/packages/react/use-overlay/src/useOverlay.tsx
+++ b/packages/react/use-overlay/src/useOverlay.tsx
@@ -36,7 +36,7 @@ export function useOverlay({ exitOnUnmount = true }: Options = {}) {
         mount(
           id,
           <OverlayController
-            key={Date.now()}
+            key={id}
             ref={overlayRef}
             overlayElement={overlayElement}
             onExit={() => {


### PR DESCRIPTION
## Overview

1. remove unused props `containerId` it is not used
2. change key of array 
The value id is generated uniquely every time overlay is used, so I think it can be used as the key of the array. Is there a any reason for using new Date() as a key?

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
4. I have written documents and tests, if needed.
