### PR TITLE
fix(rollup-config): Add `preserveModulesRoot` to our rollup config

### DIFF
--- a/configs/rollup/src/index.js
+++ b/configs/rollup/src/index.js
@@ -51,6 +51,7 @@ exports.generateRollupConfig = function generateRollupConfig({ packageDir }) {
         json(),
       ],
       preserveModules: isESMFormat,
+      preserveModulesRoot: isESMFormat ? path.dirname(output) : undefined,
     };
   }
 


### PR DESCRIPTION
## Overview

Our rollup config does not have `preserveModulesRoot`, making the directory structure of output folder `esm` wrong. 

This pull request fixes this behavior with `preserveModulesRoot`.

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
