### PR TITLE
fix(emotion-utils): remove chance to put wrong props in Stack.Horizontal/Vertical, Flex.Center/CenterVertical/CenterHorizontal

### DIFF
--- a/packages/react/emotion-utils/src/Stack.tsx
+++ b/packages/react/emotion-utils/src/Stack.tsx
@@ -1,6 +1,6 @@
 /** @tossdocs-ignore */
 /** @jsxImportSource @emotion/react */
-import { ComponentType, forwardRef, ReactElement, Ref } from 'react';
+import { ComponentProps, forwardRef, ReactElement, Ref } from 'react';
 import { Flex, FlexOptions } from './flex';
 import { gutter, GutterOptions } from './gutter';
 import { AsProps, AxisDirection, InferenceHTMLElement } from './types';
@@ -13,8 +13,8 @@ interface StackProps<T extends keyof JSX.IntrinsicElements = 'div'>
   gutter?: number;
 }
 
-type StackReturnType = <T extends keyof JSX.IntrinsicElements = 'div'>(
-  props: StackProps<T> & { ref?: Ref<InferenceHTMLElement<T>> }
+type StackReturnType<O extends string = ''> = <T extends keyof JSX.IntrinsicElements = 'div'>(
+  props: Omit<StackProps<T>, O> & { ref?: Ref<InferenceHTMLElement<T>> }
 ) => ReactElement | null;
 
 const BaseStack = forwardRef<HTMLElement, StackProps>(function BaseStack(props, ref) {
@@ -32,22 +32,17 @@ const BaseStack = forwardRef<HTMLElement, StackProps>(function BaseStack(props, 
 }) as StackReturnType;
 
 export const Stack = BaseStack as typeof BaseStack & {
-  Vertical: ComponentType<StackWithDirectionProps>;
-  Horizontal: ComponentType<StackWithDirectionProps>;
+  Vertical: StackReturnType<'direction'>;
+  Horizontal: StackReturnType<'direction'>;
 };
 
-type StackWithDirectionProps = Omit<StackProps<keyof JSX.IntrinsicElements>, 'direction'>;
-
-Stack.Horizontal = forwardRef<HTMLElement, StackWithDirectionProps>(function StackHorizontal(props, ref) {
+Stack.Horizontal = forwardRef<HTMLElement, ComponentProps<typeof Stack.Horizontal>>(function StackHorizontal(
+  props,
+  ref
+) {
   return <Stack {...props} direction="horizontal" ref={ref} />;
 });
 
-Stack.Vertical = forwardRef<HTMLElement, StackWithDirectionProps>(function StackVertical(props, ref) {
+Stack.Vertical = forwardRef<HTMLElement, ComponentProps<typeof Stack.Vertical>>(function StackVertical(props, ref) {
   return <Stack {...props} direction="vertical" ref={ref} />;
 });
-
-const Comp = () => {
-  return <Stack.Horizontal direction="horizontal"></Stack.Horizontal>;
-};
-
-console.log(Comp);

--- a/packages/react/emotion-utils/src/Stack.tsx
+++ b/packages/react/emotion-utils/src/Stack.tsx
@@ -1,7 +1,6 @@
 /** @tossdocs-ignore */
 /** @jsxImportSource @emotion/react */
-import { forwardRef, ReactElement, Ref } from 'react';
-
+import { ComponentType, forwardRef, ReactElement, Ref } from 'react';
 import { Flex, FlexOptions } from './flex';
 import { gutter, GutterOptions } from './gutter';
 import { AsProps, AxisDirection, InferenceHTMLElement } from './types';
@@ -32,19 +31,18 @@ const BaseStack = forwardRef<HTMLElement, StackProps>(function BaseStack(props, 
   );
 }) as StackReturnType;
 
-type StackType = typeof BaseStack & {
-  Vertical: typeof BaseStack;
-  Horizontal: typeof BaseStack;
-};
 
-export const Stack = BaseStack as StackType;
+export const Stack = BaseStack as typeof BaseStack & {
+  Vertical: ComponentType<StackWithDirectionProps>;
+  Horizontal: ComponentType<StackWithDirectionProps>;
+};
 
 type StackWithDirectionProps = Omit<StackProps<keyof JSX.IntrinsicElements>, 'direction'>;
 
 Stack.Horizontal = forwardRef<HTMLElement, StackWithDirectionProps>(function StackHorizontal(props, ref) {
   return <Stack direction="horizontal" {...props} ref={ref} />;
-}) as StackReturnType;
+});
 
 Stack.Vertical = forwardRef<HTMLElement, StackWithDirectionProps>(function StackVertical(props, ref) {
   return <Stack direction="vertical" {...props} ref={ref} />;
-}) as StackReturnType;
+});

--- a/packages/react/emotion-utils/src/Stack.tsx
+++ b/packages/react/emotion-utils/src/Stack.tsx
@@ -31,7 +31,6 @@ const BaseStack = forwardRef<HTMLElement, StackProps>(function BaseStack(props, 
   );
 }) as StackReturnType;
 
-
 export const Stack = BaseStack as typeof BaseStack & {
   Vertical: ComponentType<StackWithDirectionProps>;
   Horizontal: ComponentType<StackWithDirectionProps>;
@@ -40,9 +39,15 @@ export const Stack = BaseStack as typeof BaseStack & {
 type StackWithDirectionProps = Omit<StackProps<keyof JSX.IntrinsicElements>, 'direction'>;
 
 Stack.Horizontal = forwardRef<HTMLElement, StackWithDirectionProps>(function StackHorizontal(props, ref) {
-  return <Stack direction="horizontal" {...props} ref={ref} />;
+  return <Stack {...props} direction="horizontal" ref={ref} />;
 });
 
 Stack.Vertical = forwardRef<HTMLElement, StackWithDirectionProps>(function StackVertical(props, ref) {
-  return <Stack direction="vertical" {...props} ref={ref} />;
+  return <Stack {...props} direction="vertical" ref={ref} />;
 });
+
+const Comp = () => {
+  return <Stack.Horizontal direction="horizontal"></Stack.Horizontal>;
+};
+
+console.log(Comp);

--- a/packages/react/emotion-utils/src/flex.tsx
+++ b/packages/react/emotion-utils/src/flex.tsx
@@ -1,7 +1,7 @@
 /** @tossdocs-ignore */
 /** @jsxImportSource @emotion/react */
 import { css, SerializedStyles } from '@emotion/react';
-import { ComponentType, CSSProperties, forwardRef, ReactElement, Ref } from 'react';
+import { ComponentProps, CSSProperties, forwardRef, ReactElement, Ref } from 'react';
 import type { AsProps, InferenceHTMLElement } from './types';
 export interface FlexOptions {
   align?: CSSProperties['alignItems'];
@@ -43,8 +43,8 @@ flex.center = (direction?: FlexOptions['direction']) => flex({ justify: 'center'
 
 interface FlexProps<T extends keyof JSX.IntrinsicElements = 'div'> extends AsProps<T>, FlexOptions {}
 
-type FlexReturnType = <T extends keyof JSX.IntrinsicElements = 'div'>(
-  props: FlexProps<T> & { ref?: Ref<InferenceHTMLElement<T>> }
+type FlexReturnType<O extends string = ''> = <T extends keyof JSX.IntrinsicElements = 'div'>(
+  props: Omit<FlexProps<T>, O> & { ref?: Ref<InferenceHTMLElement<T>> }
 ) => ReactElement | null;
 
 export const BaseFlex = forwardRef<HTMLElement, FlexProps>(function BaseFlex(props, ref) {
@@ -56,24 +56,27 @@ export const BaseFlex = forwardRef<HTMLElement, FlexProps>(function BaseFlex(pro
 }) as FlexReturnType;
 
 type FlexType = typeof BaseFlex & {
-  Center: ComponentType<FlexWithJustifyAlignProps>;
-  CenterVertical: ComponentType<FlexWithJustifyProps>;
-  CenterHorizontal: ComponentType<FlexWithJustifyProps>;
+  Center: FlexReturnType<'align' | 'center'>;
+  CenterVertical: FlexReturnType<'align'>;
+  CenterHorizontal: FlexReturnType<'align'>;
 };
 
 export const Flex = BaseFlex as FlexType;
 
-type FlexWithJustifyAlignProps = Omit<FlexProps<keyof JSX.IntrinsicElements>, 'justify' | 'align'>;
-type FlexWithJustifyProps = Omit<FlexProps<keyof JSX.IntrinsicElements>, 'justify'>;
-
-Flex.Center = forwardRef<HTMLElement, FlexWithJustifyAlignProps>(function Center(props, ref) {
+Flex.Center = forwardRef<HTMLElement, ComponentProps<typeof Flex.Center>>(function Center(props, ref) {
   return <BaseFlex {...props} align="center" justify="center" ref={ref} />;
 });
 
-Flex.CenterVertical = forwardRef<HTMLElement, FlexWithJustifyProps>(function CenterVertical(props, ref) {
+Flex.CenterVertical = forwardRef<HTMLElement, ComponentProps<typeof Flex.CenterVertical>>(function CenterVertical(
+  props,
+  ref
+) {
   return <BaseFlex {...props} align="center" ref={ref} />;
 });
 
-Flex.CenterHorizontal = forwardRef<HTMLElement, FlexWithJustifyProps>(function CenterHorizontal(props, ref) {
+Flex.CenterHorizontal = forwardRef<HTMLElement, ComponentProps<typeof Flex.CenterHorizontal>>(function CenterHorizontal(
+  props,
+  ref
+) {
   return <BaseFlex {...props} justify="center" ref={ref} />;
 });

--- a/packages/react/emotion-utils/src/flex.tsx
+++ b/packages/react/emotion-utils/src/flex.tsx
@@ -67,13 +67,13 @@ type FlexWithJustifyAlignProps = Omit<FlexProps<keyof JSX.IntrinsicElements>, 'j
 type FlexWithJustifyProps = Omit<FlexProps<keyof JSX.IntrinsicElements>, 'justify'>;
 
 Flex.Center = forwardRef<HTMLElement, FlexWithJustifyAlignProps>(function Center(props, ref) {
-  return <BaseFlex align="center" justify="center" {...props} ref={ref} />;
+  return <BaseFlex {...props} align="center" justify="center" ref={ref} />;
 });
 
 Flex.CenterVertical = forwardRef<HTMLElement, FlexWithJustifyProps>(function CenterVertical(props, ref) {
-  return <BaseFlex align="center" {...props} ref={ref} />;
+  return <BaseFlex {...props} align="center" ref={ref} />;
 });
 
 Flex.CenterHorizontal = forwardRef<HTMLElement, FlexWithJustifyProps>(function CenterHorizontal(props, ref) {
-  return <BaseFlex justify="center" {...props} ref={ref} />;
+  return <BaseFlex {...props} justify="center" ref={ref} />;
 });

--- a/packages/react/emotion-utils/src/flex.tsx
+++ b/packages/react/emotion-utils/src/flex.tsx
@@ -1,7 +1,7 @@
 /** @tossdocs-ignore */
 /** @jsxImportSource @emotion/react */
 import { css, SerializedStyles } from '@emotion/react';
-import { CSSProperties, forwardRef, ReactElement, Ref } from 'react';
+import { ComponentType, CSSProperties, forwardRef, ReactElement, Ref } from 'react';
 import type { AsProps, InferenceHTMLElement } from './types';
 export interface FlexOptions {
   align?: CSSProperties['alignItems'];
@@ -56,27 +56,24 @@ export const BaseFlex = forwardRef<HTMLElement, FlexProps>(function BaseFlex(pro
 }) as FlexReturnType;
 
 type FlexType = typeof BaseFlex & {
-  Center: typeof BaseFlex;
-  CenterVertical: typeof BaseFlex;
-  CenterHorizontal: typeof BaseFlex;
+  Center: ComponentType<FlexWithJustifyAlignProps>;
+  CenterVertical: ComponentType<FlexWithJustifyProps>;
+  CenterHorizontal: ComponentType<FlexWithJustifyProps>;
 };
 
 export const Flex = BaseFlex as FlexType;
 
-Flex.Center = forwardRef<HTMLElement, FlexProps<keyof JSX.IntrinsicElements>>(function Center(props, ref) {
+type FlexWithJustifyAlignProps = Omit<FlexProps<keyof JSX.IntrinsicElements>, 'justify' | 'align'>;
+type FlexWithJustifyProps = Omit<FlexProps<keyof JSX.IntrinsicElements>, 'justify'>;
+
+Flex.Center = forwardRef<HTMLElement, FlexWithJustifyAlignProps>(function Center(props, ref) {
   return <BaseFlex align="center" justify="center" {...props} ref={ref} />;
 });
 
-Flex.CenterVertical = forwardRef<HTMLElement, FlexProps<keyof JSX.IntrinsicElements>>(function CenterVertical(
-  props,
-  ref
-) {
+Flex.CenterVertical = forwardRef<HTMLElement, FlexWithJustifyProps>(function CenterVertical(props, ref) {
   return <BaseFlex align="center" {...props} ref={ref} />;
 });
 
-Flex.CenterHorizontal = forwardRef<HTMLElement, FlexProps<keyof JSX.IntrinsicElements>>(function CenterHorizontal(
-  props,
-  ref
-) {
+Flex.CenterHorizontal = forwardRef<HTMLElement, FlexWithJustifyProps>(function CenterHorizontal(props, ref) {
   return <BaseFlex justify="center" {...props} ref={ref} />;
 });


### PR DESCRIPTION
# Remove chance to put wrong props in Stack.Horizontal/Vertical, Flex.Center/CenterVertical/CenterHorizontal
## AS-IS
### 1. There was chance to put wrong props in them because of wrong compound component type

![image](https://user-images.githubusercontent.com/61593290/202286902-ee3af31d-9681-4d72-bfaa-6703868693b0.png)


### 2. Not only wrong TypeScript auto complete, Also JavaScript put wrong props in component too.
For example, if Flex.Center accept `align` or `justify`, props will overide origin align, jusify too.
because of props ordering

```ts
Flex.Center = forwardRef<HTMLElement, FlexProps<keyof JSX.IntrinsicElements>>(function Center(props, ref) {
  return <BaseFlex align="center" justify="center" {...props} ref={ref} />;
});

Flex.CenterVertical = forwardRef<HTMLElement, FlexProps<keyof JSX.IntrinsicElements>>(function CenterVertical(
  props,
  ref
) {
  return <BaseFlex align="center" {...props} ref={ref} />;
});

Flex.CenterHorizontal = forwardRef<HTMLElement, FlexProps<keyof JSX.IntrinsicElements>>(function CenterHorizontal(
  props,
  ref
) {
  return <BaseFlex justify="center" {...props} ref={ref} />;
});
```


## TO-BE

### 1. Omit wrong property
```ts
type FlexReturnType<O extends string = ''> = <T extends keyof JSX.IntrinsicElements = 'div'>(
  props: Omit<FlexProps<T>, O> & { ref?: Ref<InferenceHTMLElement<T>> }
) => ReactElement | null;

type FlexType = typeof BaseFlex & {
  Center: FlexReturnType<'align' | 'center'>;
  CenterVertical: FlexReturnType<'align'>;
  CenterHorizontal: FlexReturnType<'align'>;
};

export const Flex = BaseFlex as FlexType;

```

### 2. Reorder props injecting
```ts
Flex.Center = forwardRef<HTMLElement, ComponentProps<typeof Flex.Center>>(function Center(props, ref) {
  return <BaseFlex {...props} align="center" justify="center" ref={ref} />;
});

Flex.CenterVertical = forwardRef<HTMLElement, ComponentProps<typeof Flex.CenterVertical>>(function CenterVertical(
  props,
  ref
) {
  return <BaseFlex {...props} align="center" ref={ref} />;
});

Flex.CenterHorizontal = forwardRef<HTMLElement, ComponentProps<typeof Flex.CenterHorizontal>>(function CenterHorizontal(
  props,
  ref
) {
  return <BaseFlex {...props} justify="center" ref={ref} />;
});

```


## Result
1. typescript auto complete will correct someone's mistake.
![image](https://user-images.githubusercontent.com/61593290/202289976-46c3b4dd-2840-4a04-bc7a-eea6349cba19.png)

2. also even if javascript developer without typescript autocomplete, they cannot use corner case because of corrected props order



## It can be BREAKING CHANGE to someone
It can be **BREAKING CHANGE** to someone who use wrong case like below picture
I think major version up is required if this change merged.

![image](https://user-images.githubusercontent.com/61593290/202286902-ee3af31d-9681-4d72-bfaa-6703868693b0.png)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
