### PR TITLE
feat(use-overlay): add exit function 

### DIFF
--- a/packages/react/use-overlay/src/tests/exit.spec.tsx
+++ b/packages/react/use-overlay/src/tests/exit.spec.tsx
@@ -1,42 +1,35 @@
-import { act, screen, waitFor } from '@testing-library/react';
-import React, { useEffect } from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useOverlay } from '../useOverlay';
 import { renderWithContext } from './utils';
-
-const closeDuration = 1000;
 
 function TestComponent() {
   const overlay = useOverlay();
 
-  useEffect(() => {
-    overlay.open(() => {
-      return <div>toss</div>;
-    });
-
-    const timeoutID = setTimeout(() => {
-      overlay.exit();
-    }, closeDuration);
-
-    return () => clearTimeout(timeoutID);
-  }, [overlay]);
-
-  return null;
+  return (
+    <div>
+      <button onClick={() => overlay.open(() => <div>toss</div>)}>open</button>
+      <button onClick={() => overlay.close()}>close</button>
+      <button onClick={() => overlay.exit()}>exit</button>
+    </div>
+  );
 }
 
 describe('useOverlay', () => {
   it('should unmount overlay when exit function is called', async () => {
     renderWithContext(<TestComponent />);
 
-    const overlay = screen.getByText('toss');
-    expect(overlay).toBeInTheDocument();
+    const openButton = screen.getByText('open');
+    const closeButton = screen.getByText('close');
+    const exitButton = screen.getByText('exit');
 
-    act(() => {
-      jest.advanceTimersByTime(closeDuration + 1);
-    });
+    await userEvent.click(openButton);
+    expect(screen.getByText('toss')).toBeInTheDocument();
 
-    await waitFor(() => {
-      const overlay = screen.queryByText('toss');
-      expect(overlay).toBeNull();
-    });
+    await userEvent.click(closeButton);
+    expect(screen.getByText('toss')).toBeInTheDocument();
+
+    await userEvent.click(exitButton);
+    expect(screen.queryByText('toss')).not.toBeInTheDocument();
   });
 });

--- a/packages/react/use-overlay/src/tests/exit.spec.tsx
+++ b/packages/react/use-overlay/src/tests/exit.spec.tsx
@@ -5,7 +5,7 @@ import { renderWithContext } from './utils';
 
 const closeDuration = 1000;
 
-function OverlayCallerComponent() {
+function TestComponent() {
   const overlay = useOverlay();
 
   useEffect(() => {
@@ -25,7 +25,7 @@ function OverlayCallerComponent() {
 
 describe('useOverlay', () => {
   it('should unmount overlay when exit function is called', async () => {
-    renderWithContext(<OverlayCallerComponent />);
+    renderWithContext(<TestComponent />);
 
     const overlay = screen.getByText('toss');
     expect(overlay).toBeInTheDocument();

--- a/packages/react/use-overlay/src/tests/exit.spec.tsx
+++ b/packages/react/use-overlay/src/tests/exit.spec.tsx
@@ -1,0 +1,42 @@
+import { act, screen, waitFor } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { useOverlay } from '../useOverlay';
+import { renderWithContext } from './utils';
+
+const closeDuration = 1000;
+
+function OverlayCallerComponent() {
+  const overlay = useOverlay();
+
+  useEffect(() => {
+    overlay.open(() => {
+      return <div>toss</div>;
+    });
+
+    const timeoutID = setTimeout(() => {
+      overlay.exit();
+    }, closeDuration);
+
+    return () => clearTimeout(timeoutID);
+  }, [overlay]);
+
+  return null;
+}
+
+describe('useOverlay', () => {
+  it('should unmount overlay when exit function is called', async () => {
+    renderWithContext(<OverlayCallerComponent />);
+
+    const overlay = screen.getByText('toss');
+    expect(overlay).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(closeDuration + 1);
+    });
+
+    await waitFor(() => {
+      const overlay = screen.queryByText('toss');
+      expect(overlay).toBeNull();
+    });
+  });
+});

--- a/packages/react/use-overlay/src/useOverlay.en.md
+++ b/packages/react/use-overlay/src/useOverlay.en.md
@@ -27,11 +27,13 @@ function useOverlay(options?: {
   // Set exitOnUnmount to false by disabling this behavior.
   // If you forget to run the exit function, the overlay remains in the web service indefinitely.
   // If you have set exitOnUnmount to false, you should not forget to call the exit function.
+  // The reason why we have both close and exit is that when overlay has some kind of fade-out animations,
   // default: true
   exitOnUnmount?: boolean;
 }): {
   open: (overlayElement: CreateOverlayElement) => void;
   close: () => void;
+  exit: () => void;
 };
 ```
 

--- a/packages/react/use-overlay/src/useOverlay.ko.md
+++ b/packages/react/use-overlay/src/useOverlay.ko.md
@@ -25,11 +25,13 @@ function useOverlay(options?: {
   // exitOnUnmount의 값을 false로 설정하였다면 useOverlay를 호출한 컴포넌트가 unmount 되도 overlay가 같이 unmount 되지 않습니다.
   // 따라서 원하는 타이밍에 overlay의 exit 함수를 직접 실행하여 overlay를 unmount 시킬 수 있습니다. exit 함수를 실행시키지 않는다면
   // 등록된 overlay가 메모리 상에 계속 남아있게 됩니다. exitOnUnmount의 값을 false로 설정하였다면 반드시 exit 함수를 실행시켜주세요.
+  // close와 exit이 분리되어 있는 이유는 Overlay를 닫으면서 fade-out 애니메이션을 주고 싶을 때 close와 동시에 unmount시켜버리면 애니메이션이 먹히기때문입니다.
   // default: true
   exitOnUnmount?: boolean;
 }): {
   open: (overlayElement: CreateOverlayElement) => void;
   close: () => void;
+  exit: () => void;
 };
 ```
 

--- a/packages/react/use-overlay/src/useOverlay.tsx
+++ b/packages/react/use-overlay/src/useOverlay.tsx
@@ -49,6 +49,9 @@ export function useOverlay({ exitOnUnmount = true }: Options = {}) {
       close: () => {
         overlayRef.current?.close();
       },
+      exit: () => {
+        unmount(id);
+      },
     }),
     [id, mount, unmount]
   );


### PR DESCRIPTION
## Overview

related with #146

- Abstracts and returns the function so that developers using `useOverlay` can unmount the overlay from the outside.
- wrote proper test code for verify this function

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
