### PR TITLE
refactor(emotion-utils): correct FlexReturnType naming to BaseFlexType

### DIFF
--- a/packages/react/emotion-utils/src/flex.tsx
+++ b/packages/react/emotion-utils/src/flex.tsx
@@ -43,7 +43,7 @@ flex.center = (direction?: FlexOptions['direction']) => flex({ justify: 'center'
 
 interface FlexProps<T extends keyof JSX.IntrinsicElements = 'div'> extends AsProps<T>, FlexOptions {}
 
-type FlexReturnType = <T extends keyof JSX.IntrinsicElements = 'div'>(
+type BaseFlexType = <T extends keyof JSX.IntrinsicElements = 'div'>(
   props: FlexProps<T> & { ref?: Ref<InferenceHTMLElement<T>> }
 ) => ReactElement | null;
 
@@ -53,7 +53,7 @@ export const BaseFlex = forwardRef<HTMLElement, FlexProps>(function BaseFlex(pro
   const Component = as as any;
 
   return <Component ref={ref} css={flex({ align, direction, justify })} {...rest} />;
-}) as FlexReturnType;
+}) as BaseFlexType;
 
 type FlexType = typeof BaseFlex & {
   Center: typeof BaseFlex;


### PR DESCRIPTION
## Overview
Correct naming

Wrong naming found during [this PR](https://github.com/toss/slash/pull/149)
current FlexReturnType is not return type. so I edited it

FlexReturnType => BaseFlexType


<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
