### PR TITLE
fix(emotion-utils): change name of  `StackWithDirectionProps` props

### DIFF
--- a/packages/react/emotion-utils/src/Stack.tsx
+++ b/packages/react/emotion-utils/src/Stack.tsx
@@ -39,12 +39,12 @@ type StackType = typeof BaseStack & {
 
 export const Stack = BaseStack as StackType;
 
-type StackWithDirectionProps = Omit<StackProps<keyof JSX.IntrinsicElements>, 'direction'>;
+type StackWithoutDirectionProps = Omit<StackProps<keyof JSX.IntrinsicElements>, 'direction'>;
 
-Stack.Horizontal = forwardRef<HTMLElement, StackWithDirectionProps>(function StackHorizontal(props, ref) {
+Stack.Horizontal = forwardRef<HTMLElement, StackWithoutDirectionProps>(function StackHorizontal(props, ref) {
   return <Stack direction="horizontal" {...props} ref={ref} />;
 }) as StackReturnType;
 
-Stack.Vertical = forwardRef<HTMLElement, StackWithDirectionProps>(function StackVertical(props, ref) {
+Stack.Vertical = forwardRef<HTMLElement, StackWithoutDirectionProps>(function StackVertical(props, ref) {
   return <Stack direction="vertical" {...props} ref={ref} />;
 }) as StackReturnType;


### PR DESCRIPTION
## Overview

I changed name of props `StackWithDirectionProps` => `StackWithoutDirectionProps`

Since the role of props is the type that remove `direction` from the basic `StackProps`, wouldn't `StackWithoutDirectionProps` be more appropriate for the type name than `StackWithDirectionProps`?

I'm curious about your opinion!

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
