### PR TITLE
chore: add dist, esm to ignore eslint after all packages build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist
+esm


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

add dist esm in .eslintignore to ignore eslint after all packages build
I don't want to see error in dist esm, and don't want to let them can be formatted on save.

<img width="843" alt="image" src="https://user-images.githubusercontent.com/61593290/204762092-3dee9af6-bd38-4482-b4ff-5cc2795e90e5.png">

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
