### PR TITLE
docs(react-query): remove react-query dummy docs

### DIFF
--- a/packages/react/react-query/test-d/index.test-d.ts
+++ b/packages/react/react-query/test-d/index.test-d.ts
@@ -1,3 +1,4 @@
+/** @tossdocs-ignore */
 import { expectType } from 'tsd';
 import { SuspendedUseQueryResultOnIdle, SuspendedUseQueryResultOnSuccess, useSuspendedQuery } from '../dist';
 


### PR DESCRIPTION
## Overview

![image](https://user-images.githubusercontent.com/69495129/204978675-a4300be0-54c2-4c2b-ba77-221d0de3241f.png)

[In this url](https://slash.page/libraries/react/react-query/test-d/index.test-d.ts.tossdocs) 
there is a dummy page because of test.d.ts file 
So I add tossdocs ignore comment as convention.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
