### PR TITLE
fix(utils): remove unnecessary logic in get

### DIFF
--- a/packages/common/utils/src/get-set.ts
+++ b/packages/common/utils/src/get-set.ts
@@ -5,7 +5,7 @@ export const get = <T = any>(obj: Record<string, any>, path: string, defaultValu
       .call(path, regexp)
       .filter(Boolean)
       .reduce((acc, key) => (acc !== null && acc !== undefined ? acc[key] : acc), obj);
-  const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
+  const result = travel(/[,[\].]+?/);
   return (result === undefined || result === obj ? defaultValue : result) as T;
 };
 


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->
ref #163
### AS-IS
The current `get` function has `travel` logic with use two RegExp as below.

```ts
export const get = <T = any>(obj: Record<string, any>, path: string, defaultValue?: T): T => {
  // ...
  const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
  // ...
};
```

However, the first RegExp is sufficient to replace the second RegExp, so the first is unnecessary.

### TO-BE
removed first RegExp as below.

```ts
export const get = <T = any>(obj: Record<string, any>, path: string, defaultValue?: T): T => {
  // ...
  const result = travel(/[,[\].]+?/);
  // ...
};
```

## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
