### PR TITLE
refactor(package.json): remove unnecessary files of all packages

### DIFF
--- a/packages/common/assert/package.json
+++ b/packages/common/assert/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/crypto/package.json
+++ b/packages/common/crypto/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/date/package.json
+++ b/packages/common/date/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/hangul/package.json
+++ b/packages/common/hangul/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/sentry/package.json
+++ b/packages/common/sentry/package.json
@@ -7,6 +7,10 @@
     "./nextjs": "./src/index.nextjs.ts"
   },
   "main": "./src/index.node.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "concurrently \"tsc -p tsconfig.json\" \"tsc -p tsconfig.esm.json\"",
     "prepack": "yarn build",

--- a/packages/common/storage/package.json
+++ b/packages/common/storage/package.json
@@ -8,6 +8,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "tsc --emitDeclarationOnly --outDir types && rollup -c && rm -rf types",
     "prepack": "yarn build",

--- a/packages/common/utility-types/package.json
+++ b/packages/common/utility-types/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.0",
   "sideEffects": false,
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "concurrently \"tsc -p tsconfig.json\" \"tsc -p tsconfig.esm.json\"",
     "prepack": "yarn build",

--- a/packages/common/utils/package.json
+++ b/packages/common/utils/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/validators/package.json
+++ b/packages/common/validators/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/a11y/package.json
+++ b/packages/react/a11y/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/async-boundary/package.json
+++ b/packages/react/async-boundary/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/async-stylesheet/package.json
+++ b/packages/react/async-stylesheet/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/emotion-utils/package.json
+++ b/packages/react/emotion-utils/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "prebuild": "rimraf dist esm",
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",

--- a/packages/react/error-boundary/package.json
+++ b/packages/react/error-boundary/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/framer-motion/package.json
+++ b/packages/react/framer-motion/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/impression-area/package.json
+++ b/packages/react/impression-area/package.json
@@ -8,6 +8,10 @@
     "./testing": "./src/testing/index.ts"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/lottie/package.json
+++ b/packages/react/lottie/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "lint": "yarn run -T eslint src/**/*.{js,ts,tsx}",

--- a/packages/react/react-query/package.json
+++ b/packages/react/react-query/package.json
@@ -14,6 +14,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build && yarn tsd",

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist/ && rm -rf esm/ && rollup -c && tsc --declaration --emitDeclarationOnly --declarationDir dist",
     "prepack": "yarn build",

--- a/packages/react/recoil/package.json
+++ b/packages/react/recoil/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/redirect/package.json
+++ b/packages/react/redirect/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/scroll-animation/package.json
+++ b/packages/react/scroll-animation/package.json
@@ -9,6 +9,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/use-funnel/package.json
+++ b/packages/react/use-funnel/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/use-loading/package.json
+++ b/packages/react/use-loading/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/use-overlay/package.json
+++ b/packages/react/use-overlay/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/use-query-param/package.json
+++ b/packages/react/use-query-param/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "esm"
+  ],
   "scripts": {
     "build": "rm -rf dist esm && tsc --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",


### PR DESCRIPTION
ISSUE CLOSE: #166 

## Narrow only packages's necessary files by using files field of package.json
If not using files field, @toss/slash user can see unnecessary files in node_modules like @toss/error-boundary's jest.config.js, jest.setup.ts etc.
<img width="464" alt="image" src="https://user-images.githubusercontent.com/61593290/205930139-7e077290-55e0-416d-a30c-ad6a56266f44.png">

### [files field of package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files)

I used files filed as ["dist", "esm"], but we don't have to worry about ignoring necessary files like package.json, README, LICENSE that almost be used as filename in @toss/slash. because below filename will be contained in package defaultly.

Certain files are always included, regardless of settings:
- package.json
- README
- LICENSE / LICENCE
- The file in the "main" field
- README & LICENSE can have any case and extension.

package.json have to narrow files to publish package contain only necessary. by using files field, we can narrow package's files. so I added files field in 05e1c07

### Only @toss/ky, I didn't add this solution in 05e1c07, help needed.
@toss/ky have other directory structure that should be published is different with other packages: files: ["dist", "esm"].

**Could you help this PR to narrow @toss/ky's package after build?**

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
