### PR TITLE
feat(utils): add number type to createKey result value

### DIFF
--- a/packages/common/utils/src/groupBy.spec.ts
+++ b/packages/common/utils/src/groupBy.spec.ts
@@ -1,7 +1,7 @@
 import { groupBy } from './groupBy';
 
 describe('groupBy 함수는', () => {
-  const input = [
+  const stringInput = [
     { groupName: '부엉이', value: 1 },
     { groupName: '다람쥐', value: 2 },
     { groupName: '너구리', value: 3 },
@@ -10,8 +10,8 @@ describe('groupBy 함수는', () => {
     { groupName: '부엉이', value: 6 },
   ];
 
-  it('createKey의 return value를 이용해서 item을 묶는다', () => {
-    expect(groupBy(input, ({ groupName }) => groupName)).toEqual({
+  it('createKey의 return value를 이용해서 item을 묶는다 - string type', () => {
+    expect(groupBy(stringInput, ({ groupName }) => groupName)).toEqual({
       부엉이: [
         { groupName: '부엉이', value: 1 },
         { groupName: '부엉이', value: 6 },
@@ -22,6 +22,30 @@ describe('groupBy 함수는', () => {
         { groupName: '너구리', value: 4 },
         { groupName: '너구리', value: 5 },
       ],
+    });
+  });
+
+  const numberInput = [
+    { groupName: 1, value: 1 },
+    { groupName: 1, value: 2 },
+    { groupName: 2, value: 3 },
+    { groupName: 3, value: 4 },
+    { groupName: 2, value: 5 },
+    { groupName: 1, value: 6 },
+  ];
+
+  it('createKey의 return value를 이용해서 item을 묶는다 - number type', () => {
+    expect(groupBy(numberInput, ({ groupName }) => groupName)).toEqual({
+      '1': [
+        { groupName: 1, value: 1 },
+        { groupName: 1, value: 2 },
+        { groupName: 1, value: 6 },
+      ],
+      '2': [
+        { groupName: 2, value: 3 },
+        { groupName: 2, value: 5 },
+      ],
+      '3': [{ groupName: 3, value: 4 }],
     });
   });
 

--- a/packages/common/utils/src/groupBy.ts
+++ b/packages/common/utils/src/groupBy.ts
@@ -1,5 +1,5 @@
 /** @tossdocs-ignore */
-export function groupBy<T>(data: T[], createKey: (item: T) => string) {
+export function groupBy<T>(data: T[], createKey: (item: T) => string | number) {
   return data.reduce((result: Record<string, T[]>, current) => {
     const key = createKey(current);
     const value = result[key];


### PR DESCRIPTION
## Overview

Add number type to groupBy function's createKey's return value type
Reduce function's initial value is object, object only allow key of string type. 
So we don't need to add number type to  `result: Record<string, T[]>`
It is useful for handling database results.

### **AS-IS**
```
export function groupBy<T>(data: T[], createKey: (item: T) => string) {
  return data.reduce((result: Record<string, T[]>, current) => {
    const key = createKey(current);
    const value = result[key];
    if (value == null) {
      result[key] = [current];
    } else {
      value.push(current);
    }
    return result;
  }, {});
}
```

### **TO-BE**
```
export function groupBy<T>(data: T[], createKey: (item: T) => string | number) {
  return data.reduce((result: Record<string, T[]>, current) => {
    const key = createKey(current);
    const value = result[key];
    if (value == null) {
      result[key] = [current];
    } else {
      value.push(current);
    }
    return result;
  }, {});
}
```


## PR Checklist

- [✓] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
