### PR TITLE
fix(react-query): remove chance to use generic of type SuspendedUseQueryResultOnIdle

### DIFF
--- a/packages/react/react-query/src/hooks/useSuspendedQuery.ts
+++ b/packages/react/react-query/src/hooks/useSuspendedQuery.ts
@@ -2,7 +2,7 @@
 import { QueryFunction, QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
 
 export interface BaseSuspendedUseQueryResult<TData>
-  extends Omit<UseQueryResult<TData, never>, 'data' | 'status' | 'error' | 'isLoading' | 'isError' | 'isFetching'> {
+  extends Omit<UseQueryResult, 'error' | 'isLoading' | 'isError' | 'isFetching'> {
   data: TData;
   status: 'success' | 'idle';
 }

--- a/packages/react/react-query/src/hooks/useSuspendedQuery.ts
+++ b/packages/react/react-query/src/hooks/useSuspendedQuery.ts
@@ -12,7 +12,7 @@ export type SuspendedUseQueryResultOnSuccess<TData> = BaseSuspendedUseQueryResul
   isSuccess: true;
   isIdle: false;
 };
-export type SuspendedUseQueryResultOnIdle<TData> = BaseSuspendedUseQueryResult<TData> & {
+export type SuspendedUseQueryResultOnIdle = BaseSuspendedUseQueryResult<undefined> & {
   status: 'idle';
   isSuccess: false;
   isIdle: true;
@@ -58,7 +58,7 @@ export function useSuspendedQuery<
   options: Omit<SuspendedUseQueryOptions<TQueryFnData, TError, TData, TQueryKey>, 'enabled'> & {
     enabled: false;
   }
-): SuspendedUseQueryResultOnIdle<undefined>;
+): SuspendedUseQueryResultOnIdle;
 export function useSuspendedQuery<
   TQueryFnData = unknown,
   TError = unknown,
@@ -68,7 +68,7 @@ export function useSuspendedQuery<
   queryKey: TQueryKey,
   queryFn: QueryFunction<TQueryFnData, TQueryKey>,
   options: SuspendedUseQueryOptions<TQueryFnData, TError, TData, TQueryKey>
-): SuspendedUseQueryResultOnSuccess<TData> | SuspendedUseQueryResultOnIdle<undefined>;
+): SuspendedUseQueryResultOnSuccess<TData> | SuspendedUseQueryResultOnIdle;
 export function useSuspendedQuery<
   TQueryFnData = unknown,
   TError = unknown,

--- a/packages/react/react-query/test-d/index.test-d.ts
+++ b/packages/react/react-query/test-d/index.test-d.ts
@@ -3,12 +3,15 @@ import { expectType } from 'tsd';
 import { SuspendedUseQueryResultOnIdle, SuspendedUseQueryResultOnSuccess, useSuspendedQuery } from '../dist';
 
 const queryKey = ['example'] as const;
-const queryFn = async () => 'response';
+const queryFn = async () => 'response' as const;
 
 /* eslint-disable react-hooks/rules-of-hooks */
 expectType<SuspendedUseQueryResultOnSuccess<'response'>>(useSuspendedQuery(queryKey, queryFn));
+expectType<'response'>(useSuspendedQuery(queryKey, queryFn).data);
+expectType<'response' | undefined>(useSuspendedQuery(queryKey, queryFn, { enabled: Math.random() > 0.5 }).data);
+expectType<undefined>(useSuspendedQuery(queryKey, queryFn, { enabled: false }).data);
 expectType<SuspendedUseQueryResultOnSuccess<'response'>>(useSuspendedQuery(queryKey, queryFn, { enabled: true }));
-expectType<SuspendedUseQueryResultOnIdle<undefined>>(useSuspendedQuery(queryKey, queryFn, { enabled: false }));
-expectType<SuspendedUseQueryResultOnSuccess<'response'> | SuspendedUseQueryResultOnIdle<undefined>>(
+expectType<SuspendedUseQueryResultOnIdle>(useSuspendedQuery(queryKey, queryFn, { enabled: false }));
+expectType<SuspendedUseQueryResultOnSuccess<'response'> | SuspendedUseQueryResultOnIdle>(
   useSuspendedQuery(queryKey, queryFn, { enabled: Boolean(Math.random() > 0.5) })
 );


### PR DESCRIPTION
## Remove chance to use generic of SuspendedUseQueryResultOnIdle

There was exported type `SuspendedUseQueryResultOnIdle` with generic to type TData. but SuspendedUseQueryResultOnIdle's purpose is for idle status of Promise, so It cannot be filled TData without undefined. so I remove chance to use generic of SuspendedUseQueryResultOnIdle.

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
