### PR TITLE
fix(.github): correct wrong spelling with auto format

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,9 +3,8 @@
 We welcome contribution from everyone in the community. <br/>
 All communications in this repo will be by English.
 
-> Every contributor to Slash libraries should adhere to our Code of Conduct. 
+> Every contributor to Slash libraries should adhere to our Code of Conduct.
 > <br/>Please read the [full text](./CODE_OF_CONDUCT.md) to understand what actions will and will not be tolerated.
-
 
 ## 1. Issues
 
@@ -16,8 +15,8 @@ You can contribute to Slash libraries via:
 - [Requesting a new feature or package](https://github.com/toss/slash/issues/new/choose)
 - [Having a look at our issue list](https://github.com/toss/slash/issues) to see what's to be fixed
 
-
 ## 2. Pull Requests
+
 > [Opening a pull request](https://github.com/toss/slash/compare) <br/>
 
 You can raise your own PR. The title of your PR should match the following format:
@@ -26,7 +25,7 @@ You can raise your own PR. The title of your PR should match the following forma
 <type>[package scope]: <description>
 ```
 
-> We do not care about the number, or style of commits in your history, because we squash merge every PR into main. <br/> 
+> We do not care about the number, or style of commits in your history, because we squash merge every PR into main. <br/>
 > Feel free to commit in whatever style you feel comfortable with.
 
 ### 2.1 Type
@@ -34,14 +33,17 @@ You can raise your own PR. The title of your PR should match the following forma
 **Type must be one of those**
 
 if you changed shipped code :
+
 - feat - for any new functionality additions
 - fix - for any fixes that don't add new functionality
 
 if you haven't changed shipped code :
+
 - docs - if you only change documentation
 - test - if you only change tests
 
 other :
+
 - chore - anything else
 
 ### 2.2 Package Scope
@@ -52,6 +54,3 @@ If you made changes across multiple packages, writing package scope is optional.
 ### 2.3 Description
 
 A clear and concise description of what the pr is about.
-
-
-

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,31 +1,37 @@
 ---
 name: Bug report
-about: 'Repot a bug '
-title: "[BUG]:"
+about: 'Report a bug '
+title: '[BUG]:'
 labels: ''
 assignees: ''
-
 ---
 
-### **Package Scope** 
+### **Package Scope**
+
 <!-- Is this issue related to a specific package? -->
-Package name: 
+
+Package name:
 
 ### **Describe the bug**
+
 <!-- A clear and concise description of what the bug is. -->
 
 ### **Expected behavior**
+
 <!-- A clear and concise description of what you expected to happen. -->
 
-### **To Reproduce** 
-<!-- 
-  Minimal reproducible code 
+### **To Reproduce**
+
+<!--
+  Minimal reproducible code
   or describe steps to reproduce.
   Optional, but recommended.
 -->
 
-### **Possible Solution** 
+### **Possible Solution**
+
 <!-- If you have suggestions on a fix for the bug  -->
 
-### **Additional context** 
+### **Additional context**
+
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,29 +1,33 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[Feature]:"
+title: '[Feature]:'
 labels: ''
 assignees: ''
-
 ---
 
 ### **Package Scope**
-<!-- 
+
+<!--
   Is this feature added to an existing package?
   Or make a new one?
 -->
+
 - [ ] Add to an existing package
 - [ ] New package
 
 <!-- Write the package name here -->
+
 Package name:
 
 ### **Overview**
+
 <!-- A clear and concise description about the feature -->
 
-
 ### **Describe the solution you'd like**
+
 <!-- A clear and concise description of what you want to happen -->
 
 ### **Additional context**
+
 <!-- Add any other context or screenshots about the feature request here -->


### PR DESCRIPTION
## Overview
Correct wrong spelling with auto format
1. Repot -> Report
2. Auto format by VSCode.

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
3. I have written documents and tests, if needed.
