### PR TITLE
feat(withAsyncBoundary): add withAsyncBoundary's display for development mode

### DIFF
--- a/packages/react/async-boundary/src/withAsyncBoundary.tsx
+++ b/packages/react/async-boundary/src/withAsyncBoundary.tsx
@@ -3,14 +3,19 @@ import { ComponentProps, ComponentType } from 'react';
 import AsyncBoundary from './AsyncBoundary';
 
 export default function withAsyncBoundary<Props extends Record<string, unknown> = Record<string, never>>(
-  WrappedComponent: ComponentType<Props>,
+  Component: ComponentType<Props>,
   asyncBoundaryProps: ComponentProps<typeof AsyncBoundary>
 ) {
-  return (props: Props) => {
-    return (
-      <AsyncBoundary {...asyncBoundaryProps}>
-        <WrappedComponent {...props} />
-      </AsyncBoundary>
-    );
-  };
+  const Wrapped = (props: Props) => (
+    <AsyncBoundary {...asyncBoundaryProps}>
+      <Component {...props} />
+    </AsyncBoundary>
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    const name = Component.displayName || Component.name || 'Unknown';
+    Wrapped.displayName = `withAsyncBoundary(${name})`;
+  }
+
+  return Wrapped;
 }

--- a/packages/react/async-boundary/src/withAsyncBoundary.tsx
+++ b/packages/react/async-boundary/src/withAsyncBoundary.tsx
@@ -13,7 +13,7 @@ export default function withAsyncBoundary<Props extends Record<string, unknown> 
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    const name = Component.displayName || Component.name || 'Unknown';
+    const name = Component.displayName || Component.name || 'Component';
     Wrapped.displayName = `withAsyncBoundary(${name})`;
   }
 

--- a/packages/react/error-boundary/src/index.ts
+++ b/packages/react/error-boundary/src/index.ts
@@ -2,3 +2,4 @@
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { ErrorBoundaryGroup, useErrorBoundaryGroup, withErrorBoundaryGroup } from './ErrorBoundaryGroup';
 export { default as useErrorBoundary } from './useErrorBoundary';
+export { default as withErrorBoundary } from './withErrorBoundary';

--- a/packages/react/error-boundary/src/withErrorBoundary.tsx
+++ b/packages/react/error-boundary/src/withErrorBoundary.tsx
@@ -1,0 +1,21 @@
+/** @tossdocs-ignore */
+import { ComponentProps, ComponentType } from 'react';
+import ErrorBoundary from './ErrorBoundary';
+
+export default function withErrorBoundary<Props extends Record<string, unknown> = Record<string, never>>(
+  Component: ComponentType<Props>,
+  errorBoundaryProps: ComponentProps<typeof ErrorBoundary>
+) {
+  const Wrapped = (props: Props) => (
+    <ErrorBoundary {...errorBoundaryProps}>
+      <Component {...props} />
+    </ErrorBoundary>
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    const name = Component.displayName || Component.name || 'Unknown';
+    Wrapped.displayName = `withErrorBoundary(${name})`;
+  }
+
+  return Wrapped;
+}

--- a/packages/react/error-boundary/src/withErrorBoundary.tsx
+++ b/packages/react/error-boundary/src/withErrorBoundary.tsx
@@ -13,7 +13,7 @@ export default function withErrorBoundary<Props extends Record<string, unknown> 
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    const name = Component.displayName || Component.name || 'Unknown';
+    const name = Component.displayName || Component.name || 'Component';
     Wrapped.displayName = `withErrorBoundary(${name})`;
   }
 


### PR DESCRIPTION
## Overview
1. add withAsyncBoundary's displayName for development mode
2. add withErrorBoundary like withAsyncBoundary of @toss/async-boundary

## Other Context
[🔗 Convention: Wrap the Display Name for Easy Debugging in react-docs](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
3. I have written documents and tests, if needed.
