### PR TITLE
fix(error-boundary): fix useErrorBoundary's return type to object that can have bigger scalability than before

### DIFF
--- a/packages/react/error-boundary/src/useErrorBoundary.test.tsx
+++ b/packages/react/error-boundary/src/useErrorBoundary.test.tsx
@@ -24,7 +24,9 @@ describe('useErrorBoundary', () => {
     });
 
     act(() => {
-      result.current(error);
+      const boundary = result.current;
+
+      boundary.throw(error);
     });
 
     // Then

--- a/packages/react/error-boundary/src/useErrorBoundary.ts
+++ b/packages/react/error-boundary/src/useErrorBoundary.ts
@@ -1,5 +1,5 @@
 /** @tossdocs-ignore */
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 export default function useErrorBoundary<ErrorType extends Error>() {
   const [error, setError] = useState<ErrorType | null>(null);
@@ -8,5 +8,7 @@ export default function useErrorBoundary<ErrorType extends Error>() {
     throw error;
   }
 
-  return setError;
+  const errorBoundary = useMemo(() => ({ throw: setError }), [setError]);
+
+  return errorBoundary;
 }


### PR DESCRIPTION
BREAKING CHANGE: return type is different. this will make breaking change.

## fix useErrorBoundary's return type to object that can have bigger scalability than before
I expect useErrorBoundary will provide more feature than now.
but current return type of useErrorBoundary cannot have scalability. cause it's just function.

I think this hook's return type need to be object type including throw field for scalability.

### AS-IS
```tsx
const throwError = useErrorBoundary()

return <button onClick={() => throwError(new Error(....))}/>
```

### TO-BE
```tsx
const errorBoundary = useErrorBoundary()

return <button onClick={() => errorBoundary.throw(new Error(....))}/>
```

## Other solution: rename useErrorBoundary of @toss/error-boundary into useErrorHandler of bvaughn/react-error-boundary

### AS-IS
```tsx
const throwError = useErrorBoundary()

return <button onClick={() => throwError(new Error(....))}/>
```

### TO-BE
```tsx
const handleError = useErrorHandler()

return <button onClick={() => handleError(new Error(....))}/>
```

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
