### PR TITLE
perf(error-boundary): optimize return of useErrorBoundaryGroup

### DIFF
--- a/packages/react/error-boundary/src/ErrorBoundaryGroup.spec.tsx
+++ b/packages/react/error-boundary/src/ErrorBoundaryGroup.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ErrorBoundary from './ErrorBoundary';
 import { ErrorBoundaryGroup, useErrorBoundaryGroup } from './ErrorBoundaryGroup';
@@ -50,5 +50,19 @@ describe('ErrorBoundaryGroup', () => {
     await user.click(screen.getByRole('button', { name: `Reset` }));
 
     expect(screen.getByText(`It succeeded!`)).toBeInTheDocument();
+  });
+});
+
+describe('useErrorBoundaryGroup', () => {
+  it("useErrorBoundaryGroup's returning object is same with object returned in previous render", () => {
+    const { result, rerender } = renderHook(useErrorBoundaryGroup, {
+      wrapper: ({ children }) => <ErrorBoundaryGroup>{children}</ErrorBoundaryGroup>,
+    });
+
+    const prev = result.current;
+    rerender();
+    const next = result.current;
+
+    expect(prev).toBe(next);
   });
 });

--- a/packages/react/error-boundary/src/ErrorBoundaryGroup.tsx
+++ b/packages/react/error-boundary/src/ErrorBoundaryGroup.tsx
@@ -66,7 +66,7 @@ export const ErrorBoundaryGroup = ({
 export const useErrorBoundaryGroup = () => {
   const { reset } = useContext(ErrorBoundaryGroupContext);
 
-  return { reset };
+  return useMemo(() => ({ reset }), [reset]);
 };
 
 export const withErrorBoundaryGroup =


### PR DESCRIPTION
## Overview
Optimize return of useErrorBoundaryGroup by using useMemo

### AS-IS
```tsx
const Comp = () => {
  // useErrorBoundaryGroup make new object, whenever Comp is rendered, for return type(group)
  const group = useErrorBoundaryGroup 

  ...
}
```

### TO-BE
```tsx
const Comp = () => {
  // useErrorBoundaryGroup don't make new object, whenever Comp is rendered, for return type(group) 
  const group = useErrorBoundaryGroup 

  ...
}
```

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
