### PR TITLE
refactor(react): change management useBooleanState

### DIFF
--- a/packages/react/react/src/hooks/useBooleanState.spec.ts
+++ b/packages/react/react/src/hooks/useBooleanState.spec.ts
@@ -6,18 +6,10 @@ describe('`useBooleanState`', () => {
   describe('반환 값 타입 체크', () => {
     const { result } = renderHook(useBooleanState);
 
-    const [bool, setTrue, setFalse] = result.current;
+    const [bool] = result.current;
 
     it('bool의 타입은 boolean이다.', () => {
       expect(typeof bool).toBe('boolean');
-    });
-
-    it('setTrue의 타입은 function이다.', () => {
-      expect(typeof setTrue).toBe('function');
-    });
-
-    it('setFalse의 타입은 function이다.', () => {
-      expect(typeof setFalse).toBe('function');
     });
   });
 
@@ -44,14 +36,12 @@ describe('`useBooleanState`', () => {
     });
   });
 
-  it('`setTrue` 실행 시, `bool`은 `true`가 된다.', () => {
+  it('`setBool(true)` 실행 시, `bool`은 `true`가 된다.', () => {
     {
       const { result } = renderHook(() => useBooleanState(false));
-      const [, setTrue] = result.current;
+      const [, setBool] = result.current;
 
-      act(() => {
-        setTrue();
-      });
+      act(() => setBool(true));
 
       const [bool] = result.current;
 
@@ -59,14 +49,12 @@ describe('`useBooleanState`', () => {
     }
   });
 
-  it('`setFalse` 실행 시, `bool`은 `false`가 된다.', () => {
+  it('`setBool(false)` 실행 시, `bool`은 `false`가 된다.', () => {
     {
       const { result } = renderHook(() => useBooleanState(true));
-      const [, , setFalse] = result.current;
+      const [, setBool] = result.current;
 
-      act(() => {
-        setFalse();
-      });
+      act(() => setBool(false));
 
       const [bool] = result.current;
 
@@ -76,10 +64,10 @@ describe('`useBooleanState`', () => {
 
   it('`toggle` 실행 시, `bool`은 `true` -> `false`, `false` -> `true`가 된다.', () => {
     const { result } = renderHook(() => useBooleanState(true));
-    const [, , , toggle] = result.current;
+    const [, setBool] = result.current;
 
     {
-      act(toggle);
+      act(() => setBool());
 
       const [bool] = result.current;
 
@@ -87,7 +75,7 @@ describe('`useBooleanState`', () => {
     }
 
     {
-      act(toggle);
+      act(() => setBool());
 
       const [bool] = result.current;
 
@@ -95,7 +83,7 @@ describe('`useBooleanState`', () => {
     }
 
     {
-      act(toggle);
+      act(() => setBool());
 
       const [bool] = result.current;
 

--- a/packages/react/react/src/hooks/useBooleanState.ts
+++ b/packages/react/react/src/hooks/useBooleanState.ts
@@ -14,7 +14,10 @@ import { useCallback, useState } from 'react';
 export const useBooleanState = (defaultValue = false): readonly [boolean, (state?: boolean) => void] => {
   const [bool, setBool] = useState(defaultValue);
 
-  const boolValue = useCallback((state?: boolean) => setBool(b => (typeof state === 'boolean' ? state : !b)), []);
+  const handleBoolChange = useCallback(
+    (state?: boolean) => setBool(b => (typeof state === 'boolean' ? state : !b)),
+    []
+  );
 
-  return [bool, boolValue] as const;
+  return [bool, handleBoolChange] as const;
 };

--- a/packages/react/react/src/hooks/useBooleanState.ts
+++ b/packages/react/react/src/hooks/useBooleanState.ts
@@ -5,26 +5,16 @@ import { useCallback, useState } from 'react';
  * boolean 타입으로 useState를 쉽게 사용할 수 있는 hook 입니다.
  *
  * ```ts
- * function useBooleanState(defaultValue = false): readonly [bool, setTrue, setFalse, toggle];
+ * function useBooleanState(defaultValue = false): readonly [bool, boolValue];
  * ```
  *
  * @example
- * const [open, openBottomSheet, closeBottomSheet, toggleBottomSheet] = useBooleanState(false);
+ * const [open, setOpen] = useBooleanState(false);
  */
-export const useBooleanState = (defaultValue = false): readonly [boolean, () => void, () => void, () => void] => {
+export const useBooleanState = (defaultValue = false): readonly [boolean, (state?: boolean) => void] => {
   const [bool, setBool] = useState(defaultValue);
 
-  const setTrue = useCallback(() => {
-    setBool(true);
-  }, []);
+  const boolValue = useCallback((state?: boolean) => setBool(b => (typeof state === 'boolean' ? state : !b)), []);
 
-  const setFalse = useCallback(() => {
-    setBool(false);
-  }, []);
-
-  const toggle = useCallback(() => {
-    setBool(b => !b);
-  }, []);
-
-  return [bool, setTrue, setFalse, toggle] as const;
+  return [bool, boolValue] as const;
 };


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I changed the method of managing the state of useboolean. I adjusted the boolean value in three ways: setTrue, setFalse, and toggle, but I succeeded in unifying it with one setBool. Users no longer have to call in three things and can control the state with just one.

**The existing one is as below**
```tsx
const [bool, setTrue, setFalse, toggle] = useBooleanState();

setFalse() // change false
setTrue() // change true
toggle() // toggle

bool // use

```

**The improvement is as follows**
```tsx
const [bool, setBool] = useBooleanState();

setBool(false) // change false
setBool(true) // change true
setBool() // toggle

bool // use

```

I revised the test code accordingly

![image](https://user-images.githubusercontent.com/77133565/215290883-58843928-46ff-4828-9cff-eee581d64476.png)


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
