### PR TITLE
fix(react): make correct way to use useCallback's dependencyList in useCombinedRefs

### DIFF
--- a/packages/react/react/src/hooks/useCombinedRefs.ts
+++ b/packages/react/react/src/hooks/useCombinedRefs.ts
@@ -29,6 +29,7 @@ export function useCombinedRefs<T>(...refs: Array<Ref<T> | CallbackRef<T>>): Ref
         }
       }
     },
-    [refs]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    refs
   );
 }


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

### AS-IS

```ts
export function useCombinedRefs<T>(...refs: Array<Ref<T> | CallbackRef<T>>): Ref<T> {
  return useCallback(
    (value: T) => {
      for (const ref of refs) {
        if (typeof ref === 'function') {
          ref(value);
        } else if (ref != null) {
          (ref as MutableRefObject<T>).current = value;
        }
      }
    },
    [refs] // always new reference of refs
  );
}
```

Inside of useCombinedRefs, refs arrary will be always new array between re-renders. so useCallback in useCombinedRefs have no [feature of caching function definition between re-renders](https://beta.reactjs.org/reference/react/useCallback) so I spread it to fix it correctly.
and then I added eslint-disable-next-line.

### TO-BE

```ts
export function useCombinedRefs<T>(...refs: Array<Ref<T> | CallbackRef<T>>): Ref<T> {
  return useCallback(
    (value: T) => {
      for (const ref of refs) {
        if (typeof ref === 'function') {
          ref(value);
        } else if (ref != null) {
          (ref as MutableRefObject<T>).current = value;
        }
      }
    },
    // eslint-disable-next-line react-hooks/exhaustive-deps
    refs  // refs array's item can have same reference, so It make optimization
  );
}
```

chakra-ui optimize correctly too like this. you can check it in [@chakra-ui's useMergeRefs](https://github.com/chakra-ui/chakra-ui/blob/main/packages/hooks/use-merge-refs/src/index.ts?rgh-link-date=2023-02-02T13%3A39%3A32Z)

I made this PR because this https://github.com/toss/slash/pull/211#pullrequestreview-1281065015 is closed.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
