### PR TITLE
docs(react): fix example of useCombinedRefs's js-doc

### DIFF
--- a/packages/react/react/src/hooks/useCombinedRefs.ts
+++ b/packages/react/react/src/hooks/useCombinedRefs.ts
@@ -11,7 +11,7 @@ type CallbackRef<T> = (ref: T | null) => void;
  *
  * @example
  * const SomeComponent = forwardRef((props, parentRef) => {
- *   const myRef = useRef();
+ *   const myRef = useRef(null);
  *   const ref = useCombinedRefs(myRef, parentRef);
  *
  *   // 하단 div가 업데이트되면 myRef와 parentRef 모두가 업데이트됨


### PR DESCRIPTION
## Overview
@HoseungJang, I found you want to prevent that useCombinedRefs accept MutableRefObject in https://github.com/toss/slash/pull/211#discussion_r1097071688. so I understood why useCombinedRefs not accepting MutableRefObject is to prevent ref.current's mutation by readonly field of RefObject, making TypeScript error if trying mutation of ref.current.

But, in example, useCombinedRefs accept MutableRefObject, so I fixed it.

also Thanks to @tooooo1 that make this https://github.com/toss/slash/pull/211

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
