### PR TITLE
fix(utils): remove the type that deleted the symbol which name is `ObjectKeys`.

### DIFF
--- a/packages/common/utils/src/object/pick.spec.ts
+++ b/packages/common/utils/src/object/pick.spec.ts
@@ -19,4 +19,22 @@ describe('pick', () => {
       JP: 'JP',
     });
   });
+  it('should create an object composed of the given symbol keys', () => {
+    const FooSymbol = Symbol('foo');
+    const BarSymbol = Symbol('bar');
+
+    const symbols = {
+      [FooSymbol]: 'foo',
+      [BarSymbol]: 'bar',
+    } as const;
+
+    expect(pick(symbols, [FooSymbol])).toStrictEqual({
+      [FooSymbol]: 'foo',
+    });
+
+    expect(pick(symbols, [FooSymbol])).not.toStrictEqual({
+      [FooSymbol]: 'foo',
+      [BarSymbol]: 'bar',
+    });
+  });
 });

--- a/packages/common/utils/src/object/pick.ts
+++ b/packages/common/utils/src/object/pick.ts
@@ -1,8 +1,7 @@
 /** @tossdocs-ignore */
-import { ObjectKeys } from '.';
 import { ElementType } from './types';
 
-export function pick<ObjectType extends Record<PropertyKey, unknown>, KeyTypes extends Array<ObjectKeys<ObjectType>>>(
+export function pick<ObjectType extends Record<PropertyKey, unknown>, KeyTypes extends Array<keyof ObjectType>>(
   obj: ObjectType,
   keys: KeyTypes
 ) {


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Although the object's key value could be a symbol, the array of keys was blocked from entering the symbol.

I think I've limited it in the past because of [this issue](https://github.com/microsoft/TypeScript/issues/24622), but now the keyof command works well for the object to which the symbol belongs.

If there's any other reason why `pick` function blocked the symbol, please tell me!

## Screenshot in my vscode

![image](https://user-images.githubusercontent.com/69495129/220356516-2f2cca3c-1127-4cf9-8b89-28c054aaf072.png)



## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
