### PR TITLE
docs(@toss/uitls): add NonEmptyArray example

### DIFF
--- a/packages/common/utils/src/array/NonEmptyArray.en.md
+++ b/packages/common/utils/src/array/NonEmptyArray.en.md
@@ -1,3 +1,25 @@
 # NonEmptyArray
 
-A type which indicates that an array is not empty. We can assert an array not to be empty by `isNonEmptyArray` function.
+A type which indicates that an array is not empty.
+
+```typescript
+type NonEmptyArray<T> = [T, ...T[]];
+```
+
+- You can use this to create a function like [isNonEmptyArray](https://slash.page/ko/libraries/common/utils/src/array/isnonemptyarray.i18n/) that checks if an array has at least one element.
+
+# Example
+
+```typescript
+// There is no problem at the time of declaration, but runtime errors may occur depending on the internal logic.
+const getSum = (array: number[]) => array.reduce((x, y) => x + y);
+
+// [ERR]: Reduce of empty array with no initial value
+getSum([]);
+
+// Runtime errors can be prevented through type errors at the time of declaration.
+const getSum = (array: NonEmptyArray<number>) => array.reduce((x, y) => x + y);
+
+// Argument of type '[]' is not assignable to parameter of type 'NonEmptyArray<number>'. Source has 0 element(s) but target requires
+getSum([]);
+```

--- a/packages/common/utils/src/array/NonEmptyArray.ko.md
+++ b/packages/common/utils/src/array/NonEmptyArray.ko.md
@@ -1,3 +1,25 @@
 # NonEmptyArray
 
 비어 있지 않은 배열을 나타내는 타입입니다.
+
+```typescript
+type NonEmptyArray<T> = [T, ...T[]];
+```
+
+- 이를 이용하여 [isNonEmptyArray](https://slash.page/ko/libraries/common/utils/src/array/isnonemptyarray.i18n/) 와 같은 배열이 최소 1개 이상의 원소를 가지고 있는지 확인하는 함수를 만들 수 있습니다.
+
+# Example
+
+```typescript
+// 선언 당시에는 문제가 없으나 내부 로직에 따라 런타임 에러가 발생할 수 있습니다.
+const getSum = (array: number[]) => array.reduce((x, y) => x + y);
+
+// [ERR]: Reduce of empty array with no initial value
+getSum([]);
+
+// 선언 당시에 type error를 통해 runtime error를 방지할 수 있습니다.
+const getSum = (array: NonEmptyArray<number>) => array.reduce((x, y) => x + y);
+
+// Argument of type '[]' is not assignable to parameter of type 'NonEmptyArray<number>'. Source has 0 element(s) but target requires
+getSum([]);
+```


### PR DESCRIPTION
## Overview
<img width="858" alt="image" src="https://user-images.githubusercontent.com/54930877/220949185-cf61cf50-f21a-4455-9b8f-6e4c61840375.png">
<img width="700" alt="image" src="https://user-images.githubusercontent.com/54930877/220949707-4b244ada-c1b2-4de1-aafd-c044e8dd39d4.png">

- 영어문서와 한글 문서의 내용이 달라 통일해주었습니다.
- 타입 형태와 example이 빠져 있어 예시 코드를 추가해주었습니다. 
- `isNonEmptyArray` util에서 해당 타입을 사용하고 있어 `isNonEmptyArray`와 관련된 설명과 링크를 추가해주었습니다.


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
