### PR TITLE
docs(i18n):  Edit banner style

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
@@ -3,6 +3,14 @@ title: 소개
 hide_table_of_contents: true
 ---
 
+<div class="jumbotron">
+  <div class="jumbotron-inner-wrapper">
+    <div class="jumbotron-shadow left"></div>
+    <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay="true" muted="true" playsInline="true" loop="true" />
+    <div class="jumbotron-shadow right"></div>
+  </div>
+</div>
+
 # Slash 라이브러리
 
 <head>
@@ -25,10 +33,6 @@ hide_table_of_contents: true
   <p><code>⌘ + K</code>를 입력해서 라이브러리 문서를 탐색해보세요.</p>
 
   </div>
-
-  <div style={{ gridArea: 'image', textAlign: 'center' }}>
-  <video class="key-video" src="https://static.toss.im/assets/slash-libraries/keyvis.mp4" autoplay="true" muted="true" playsInline="true" loop="true" />
-  </div>
 </div>
 
 <style
@@ -38,6 +42,40 @@ hide_table_of_contents: true
   display: grid;
 }
 
+.jumbotron {
+  width: 100%;
+  height: 200px;
+  border-radius: 16px;
+  background: black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 36px;
+  overflow: hidden;
+}
+
+.jumbotron-shadow {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 25px;
+}
+
+.jumbotron-shadow.left {
+  left: 0;
+  background: linear-gradient(90deg, #000000 0%, rgba(0, 0, 0, 0) 100%);
+}
+
+.jumbotron-shadow.right {
+  right: 0;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, #000000 100%);
+}
+
+.jumbotron-inner-wrapper {
+  position: relative;
+  height: 100%;
+}
+
 @media (min-width: 600px) {
   .mainpage_hero {
     grid-template-areas: "text image";
@@ -45,8 +83,8 @@ hide_table_of_contents: true
   }
 
   .key-video {
-    width: 260px;
-    height: 146px;
+    width: auto;
+    height: 100%;
   }
 }
 
@@ -57,8 +95,8 @@ hide_table_of_contents: true
   }
 
   .key-video {
-    width: 80%;
-    margin: 24px auto;
+    width: auto;
+    height: 100%;
   }
 }
 `,

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -34,6 +34,7 @@ hide_table_of_contents: true
   <p>
     Use <code>⌘ + K</code> to search through our libraries documentation.
   </p>
+
   </div>
 </div>
 
@@ -76,7 +77,7 @@ hide_table_of_contents: true
 .jumbotron-inner-wrapper {
   position: relative;
   height: 100%;
-  }
+}
 
 @media (min-width: 600px) {
   .mainpage_hero {


### PR DESCRIPTION
## Overview

<img width="1149" alt="image" src="https://user-images.githubusercontent.com/54930877/221420140-19c1b61a-2b11-44d2-a0d5-e30266ce3588.png">

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/54930877/221420152-eb83dc71-8ae0-4a80-90ec-549cc16e2687.png">

- The part where the banner looks different on the English page and the Korean page is unified to match the English page.
- The reason why I changed it to English page is because the commit log of the banner addition code is more recent. (I think the English page is prettier aesthetically 👀)
## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
