### PR TITLE
fix(react): infer defaultValue as primitive type

### DIFF
--- a/packages/react/react/src/hooks/useStorageState.spec.ts
+++ b/packages/react/react/src/hooks/useStorageState.spec.ts
@@ -140,7 +140,7 @@ function createMockStorage() {
   };
 }
 
-function createFixture<T>({ defaultValue }: { defaultValue?: Serializable<T> } = {}) {
+function createFixture<T extends Serializable>({ defaultValue }: { defaultValue?: T } = {}) {
   const key = '@@test-key';
   const storage = createMockStorage();
   const render = () => renderHook(() => useStorageState<T>(key, { storage, defaultValue }));

--- a/packages/react/react/src/hooks/useStorageState.ts
+++ b/packages/react/react/src/hooks/useStorageState.ts
@@ -19,15 +19,15 @@ interface StorageStateOptionsWithDefaultValue<T> extends StorageStateOptions<T> 
 export function useStorageState<T extends Serializable>(
   key: string
 ): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void];
-export function useStorageState<T>(
+export function useStorageState<T extends Serializable>(
   key: string,
   { storage, defaultValue }: StorageStateOptionsWithDefaultValue<T>
 ): readonly [T, (value: SetStateAction<T>) => void, () => void];
-export function useStorageState<T>(
+export function useStorageState<T extends Serializable>(
   key: string,
   { storage, defaultValue }: StorageStateOptions<T>
 ): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void];
-export function useStorageState<T>(
+export function useStorageState<T extends Serializable>(
   key: string,
   { storage = safeLocalStorage, defaultValue }: StorageStateOptions<T> = {}
 ): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void] {

--- a/packages/react/react/src/hooks/useStorageState.ts
+++ b/packages/react/react/src/hooks/useStorageState.ts
@@ -57,7 +57,7 @@ export function useStorageState<T extends Serializable>(
   const set = useCallback(
     (value: SetStateAction<T | undefined>) => {
       setState(curr => {
-        const nextValue = value instanceof Function ? value(curr) : value;
+        const nextValue = typeof value === 'function' ? value(curr) : value;
 
         if (nextValue == null) {
           storage.remove(key);

--- a/packages/react/react/src/hooks/useStorageState.ts
+++ b/packages/react/react/src/hooks/useStorageState.ts
@@ -2,36 +2,35 @@
 import { safeLocalStorage, Storage } from '@toss/storage';
 import { SetStateAction, useCallback, useState } from 'react';
 
-export type Serializable<T> = T extends string | number | boolean | unknown[] | Record<string, unknown> ? T : never;
-
+export type Serializable = string | number | boolean | unknown[] | Record<string, unknown>;
 interface StorageStateOptions<T> {
   storage?: Storage;
-  defaultValue?: Serializable<T>;
+  defaultValue?: T;
 }
 
 interface StorageStateOptionsWithDefaultValue<T> extends StorageStateOptions<T> {
-  defaultValue: Serializable<T>;
+  defaultValue: T;
 }
 
 /**
  * 스토리지에 상태값을 저장하고 불러와서 값이 보존되는 useState로 동작하는 hook입니다.
  * @param key 스토리지에 저장할 키
  */
-export function useStorageState<T>(
+export function useStorageState<T extends Serializable>(
   key: string
-): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void, () => void];
+): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void];
 export function useStorageState<T>(
   key: string,
   { storage, defaultValue }: StorageStateOptionsWithDefaultValue<T>
-): readonly [Serializable<T>, (value: SetStateAction<Serializable<T>>) => void, () => void];
+): readonly [T, (value: SetStateAction<T>) => void, () => void];
 export function useStorageState<T>(
   key: string,
   { storage, defaultValue }: StorageStateOptions<T>
-): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void, () => void];
+): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void];
 export function useStorageState<T>(
   key: string,
   { storage = safeLocalStorage, defaultValue }: StorageStateOptions<T> = {}
-): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void, () => void] {
+): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void] {
   const getValue = useCallback(<T>() => {
     const data = storage.get(key);
 
@@ -53,12 +52,12 @@ export function useStorageState<T>(
     }
   }, [defaultValue, key, storage]);
 
-  const [state, setState] = useState<Serializable<T> | undefined>(getValue);
+  const [state, setState] = useState<T | undefined>(getValue);
 
   const set = useCallback(
-    (value: SetStateAction<Serializable<T> | undefined>) => {
+    (value: SetStateAction<T | undefined>) => {
       setState(curr => {
-        const nextValue = typeof value === 'function' ? value(curr) : value;
+        const nextValue = value instanceof Function ? value(curr) : value;
 
         if (nextValue == null) {
           storage.remove(key);


### PR DESCRIPTION
## defaultValue in useStorageState inferred as a literal type

````typescript
// const state: 0       Before this PR
// const state: number  After this PR
const [state, setState, refresh] = useStorageState('number', {
  defaultValue: 0
})
````

This pull request updates the type definition of defaultValue in codebase to be inferred as a primitive type instead of a literal value. 

To achieve this, I updated the `useStorageState` function's generic type parameter to extends `Serializable` instead of using defaultValue as a `Serializable<T>`.

Pull Request about https://github.com/toss/slash/issues/220

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
