### PR TITLE
test(emotion-utils): remove useless import statement

### DIFF
--- a/packages/react/emotion-utils/src/utils/position.test.tsx
+++ b/packages/react/emotion-utils/src/utils/position.test.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 import { matchers } from '@emotion/jest';
-import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import { position } from './position';
 


### PR DESCRIPTION
## Overview

`import '@testing-library/jest-dom';` statement is declared in jest.setup.ts so in test file it is useless! 
so I removed it

<img width="1372" alt="image" src="https://user-images.githubusercontent.com/69495129/225515794-c2f480e9-64fe-4f64-af71-65dc8caa8dce.png">


<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
