### PR TITLE
fix(use-query-param): do narrow type of useNextRouter

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -10216,6 +10216,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react", "npm:18.0.21"],\
             ["@types/react-dom", "npm:18.0.6"],\
             ["@types/testing-library__jest-dom", "npm:5.14.5"],\
+            ["@yarnpkg/pnpify", "npm:4.0.0-rc.27"],\
             ["babel-jest", "virtual:785204e63ba96625a23f896ee431c9a36baff7a533742c7d2c1d3e8c51b41da4d9b22d61afa2e1bb44d0338b2a9e895a7c77e29d79f3a357a12dae28feb7f916#npm:29.1.2"],\
             ["concurrently", "npm:6.5.1"],\
             ["jest", "virtual:01ae7c33d4655a48cbb29902912466a761e01d57e32af25620c31e36065eb1601cc4f6394afcb6b2f9c9f1b941b9fbeecba9aa1bca8ca304ae87cee07a6864e9#npm:29.1.2"],\
@@ -10257,6 +10258,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react", "npm:18.0.21"],\
             ["@types/react-dom", "npm:18.0.6"],\
             ["@types/testing-library__jest-dom", "npm:5.14.5"],\
+            ["@yarnpkg/pnpify", "npm:4.0.0-rc.27"],\
             ["babel-jest", "virtual:785204e63ba96625a23f896ee431c9a36baff7a533742c7d2c1d3e8c51b41da4d9b22d61afa2e1bb44d0338b2a9e895a7c77e29d79f3a357a12dae28feb7f916#npm:29.1.2"],\
             ["concurrently", "npm:6.5.1"],\
             ["jest", "virtual:01ae7c33d4655a48cbb29902912466a761e01d57e32af25620c31e36065eb1601cc4f6394afcb6b2f9c9f1b941b9fbeecba9aa1bca8ca304ae87cee07a6864e9#npm:29.1.2"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -10225,6 +10225,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react", "npm:18.2.0"],\
             ["react-dom", "virtual:62cb29918b2e63dff97923d985a18238631a18b918521fd9ac48de2be213715676e8b999d7ab4431ea536d1917af1465d5695ceae059c69bf4c14df5968dd6a1#npm:18.2.0"],\
             ["rollup", "npm:2.79.1"],\
+            ["tsd", "npm:0.24.1"],\
             ["typescript", "patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"]\
           ],\
           "packagePeers": [\
@@ -10265,6 +10266,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react", "npm:18.2.0"],\
             ["react-dom", "virtual:62cb29918b2e63dff97923d985a18238631a18b918521fd9ac48de2be213715676e8b999d7ab4431ea536d1917af1465d5695ceae059c69bf4c14df5968dd6a1#npm:18.2.0"],\
             ["rollup", "npm:2.79.1"],\
+            ["tsd", "npm:0.24.1"],\
             ["typescript", "patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"]\
           ],\
           "linkType": "SOFT"\

--- a/packages/react/use-query-param/package.json
+++ b/packages/react/use-query-param/package.json
@@ -2,6 +2,10 @@
   "name": "@toss/use-query-param",
   "version": "1.1.6",
   "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "tsd": {
+    "directory": "./test-d"
+  },
   "exports": {
     ".": {
       "require": "./src/index.ts",
@@ -16,7 +20,8 @@
   ],
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
-    "prepack": "yarn build",
+    "prepack": "yarn build && yarn tsd",
+    "tsd": "pnpify tsd",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },
@@ -45,6 +50,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup": "^2.77.0",
+    "tsd": "^0.24.1",
     "typescript": "4.8.3"
   },
   "peerDependencies": {

--- a/packages/react/use-query-param/package.json
+++ b/packages/react/use-query-param/package.json
@@ -41,6 +41,7 @@
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "@types/testing-library__jest-dom": "^5",
+    "@yarnpkg/pnpify": "^4.0.0-rc.27",
     "babel-jest": "^29.0.1",
     "concurrently": "^6.0.0",
     "jest": "^29.0.1",

--- a/packages/react/use-query-param/src/hooks/useNextRouter.ts
+++ b/packages/react/use-query-param/src/hooks/useNextRouter.ts
@@ -1,11 +1,18 @@
 /** @tossdocs-ignore */
-import { useRouter } from 'next/router';
+import { NextRouter, useRouter } from 'next/router';
 import { waitForRouterReady } from '../utils/waitForRouterReady';
 
 interface Options {
   suspense?: boolean;
 }
 
+interface ReadyNextRouter extends NextRouter {
+  isReady: true;
+}
+
+export function useNextRouter(options: { suspense: true }): ReadyNextRouter;
+export function useNextRouter(): ReadyNextRouter;
+export function useNextRouter(options?: { suspense?: boolean }): NextRouter;
 export function useNextRouter(options: Options = { suspense: true }) {
   const router = useRouter();
 

--- a/packages/react/use-query-param/test-d/index.test-d.ts
+++ b/packages/react/use-query-param/test-d/index.test-d.ts
@@ -1,0 +1,13 @@
+/** @tossdocs-ignore */
+import { expectType } from 'tsd';
+import { useNextRouter } from '../dist';
+
+const boolean = Math.random() > 0.5;
+
+/* eslint-disable react-hooks/rules-of-hooks */
+expectType<true>(useNextRouter({ suspense: true }).isReady);
+expectType<true>(useNextRouter().isReady);
+expectType<boolean>(useNextRouter({ suspense: boolean }).isReady);
+expectType<boolean>(useNextRouter({ suspense: false }).isReady);
+expectType<boolean>(useNextRouter({ suspense: undefined }).isReady);
+expectType<boolean>(useNextRouter({}).isReady);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6184,6 +6184,7 @@ __metadata:
     "@types/react": ^18.0.21
     "@types/react-dom": ^18.0.6
     "@types/testing-library__jest-dom": ^5
+    "@yarnpkg/pnpify": ^4.0.0-rc.27
     babel-jest: ^29.0.1
     concurrently: ^6.0.0
     jest: ^29.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -6193,6 +6193,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     rollup: ^2.77.0
+    tsd: ^0.24.1
     typescript: 4.8.3
   peerDependencies:
     next: ^11.1 || ^12


### PR DESCRIPTION
## do narrow type of useNextRouter
If using suspense, useNextRouter().isReady don't need to be boolean. so I corrected it and add test code.

### referenece
![image](https://github.com/toss/slash/assets/61593290/2d153ec7-2ecd-415a-95fa-990d0d571332)

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
