### PR TITLE
fix(@toss/storage): Add typed.d.ts file for subpath module

### DIFF
--- a/packages/common/storage/package.json
+++ b/packages/common/storage/package.json
@@ -10,7 +10,8 @@
   "main": "./src/index.ts",
   "files": [
     "dist",
-    "esm"
+    "esm",
+    "typed.d.ts"
   ],
   "scripts": {
     "build": "tsc --emitDeclarationOnly --outDir types && rollup -c && rm -rf types",

--- a/packages/common/storage/typed.d.ts
+++ b/packages/common/storage/typed.d.ts
@@ -1,0 +1,2 @@
+/** @tossdocs-ignore */
+export * from './dist/typed';

--- a/packages/common/storage/typed.ts
+++ b/packages/common/storage/typed.ts
@@ -1,2 +1,0 @@
-/** @tossdocs-ignore */
-export * from './src/typed';


### PR DESCRIPTION
## Overview

I delete uselsess typed.ts file in root path in @toss/storage [66f44a2](https://github.com/toss/slash/commit/66f44a217a638b4bc3205239a5fdcb6b2048eb07)

Add typed.d.ts file for subpath module in @toss/storage (/typed) [16d3c64](https://github.com/toss/slash/commit/16d3c647febdb7739016a97bece0a92bc98e509d)

relates to #243 

Thanks to providing simple solution @HoseungJang (https://github.com/toss/slash/pull/247#issuecomment-1575288949)

## Question

In PR #247, I updated rollup.config.js by using @toss/rollup-config.
I think in this package too, it is simple way for building files by using @toss/rollup-config
If you agree about update rollup.config.js, can i update that file in this PR? or new branch and create PR.


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
