### PR TITLE
fix(utils): fix typo

### DIFF
--- a/packages/common/utils/src/Numbers_formatToKRW.en.md
+++ b/packages/common/utils/src/Numbers_formatToKRW.en.md
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: formatToKRW
 ---
 
-# formatToKoreanNumber
+# formatToKRW
 
 Converts given number to Korean expression.
 

--- a/packages/common/utils/src/Numbers_formatToKRW.en.md
+++ b/packages/common/utils/src/Numbers_formatToKRW.en.md
@@ -5,7 +5,7 @@ sidebar_label: formatToKRW
 
 # formatToKRW
 
-Converts given number to Korean expression.
+Formats the given number into Korean currency format (KRW).
 
 ```typescript
 function formatToKRW(

--- a/packages/common/utils/src/Numbers_formatToKRW.ko.md
+++ b/packages/common/utils/src/Numbers_formatToKRW.ko.md
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: formatToKRW
 ---
 
-# formatToKoreanNumber
+# formatToKRW
 
 주어진 수를 한국어 표기로 변환합니다.
 

--- a/packages/common/utils/src/Numbers_formatToKRW.ko.md
+++ b/packages/common/utils/src/Numbers_formatToKRW.ko.md
@@ -5,7 +5,7 @@ sidebar_label: formatToKRW
 
 # formatToKRW
 
-주어진 수를 한국어 표기로 변환합니다.
+주어진 숫자를 한국 원화 형식으로 포맷합니다.
 
 ```typescript
 function formatToKRW(


### PR DESCRIPTION
## Overview

I think there might be incorrect content remaining while copying from formatToKoreanNumber document

- fix typo in formatToKRW docs title (formatToKoreanNumber -> formatToKRW)
- update desccription

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
