### PR TITLE
docs(i18n): fix link for en docs to ko docs

### DIFF
--- a/packages/common/date/src/docs/getDateDistanceText.en.md
+++ b/packages/common/date/src/docs/getDateDistanceText.en.md
@@ -1,6 +1,6 @@
 # getDateDistanceText
 
-Formats a value returned by [getDateDistance()](https://slash.page/ko/libraries/common/date/src/docs/getdatedistance.i18n).
+Formats a value returned by [getDateDistance()](https://slash.page/libraries/common/date/src/docs/getdatedistance.i18n).
 
 ```typescript
 function getDateDistanceText(

--- a/packages/common/utils/src/array/NonEmptyArray.en.md
+++ b/packages/common/utils/src/array/NonEmptyArray.en.md
@@ -6,7 +6,7 @@ A type which indicates that an array is not empty.
 type NonEmptyArray<T> = [T, ...T[]];
 ```
 
-- You can use this to create a function like [isNonEmptyArray](https://slash.page/ko/libraries/common/utils/src/array/isnonemptyarray.i18n/) that checks if an array has at least one element.
+- You can use this to create a function like [isNonEmptyArray](https://slash.page/libraries/common/utils/src/array/isnonemptyarray.i18n/) that checks if an array has at least one element.
 
 # Example
 

--- a/packages/common/utils/src/array/arrayIncludes.en.md
+++ b/packages/common/utils/src/array/arrayIncludes.en.md
@@ -1,6 +1,6 @@
 # arrayIncludes
 
-A utility function to help removing type assertions when using [Array.prototype.includes()](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/includes).
+A utility function to help removing type assertions when using [Array.prototype.includes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes).
 
 ## Example
 

--- a/packages/common/utils/src/array/last.en.md
+++ b/packages/common/utils/src/array/last.en.md
@@ -8,7 +8,7 @@ function last<T>(arr: T[]): T | undefined;
 ```
 
 - If an array is a normal array (`T[]`), `last` returns a nullable value, since it can be empty.
-- If an array is checked not to be empty by [isNonEmptyArray](https://slash.page/ko/libraries/common/utils/src/array/isnonemptyarray.i18n), `last` returns a non-nullable value.
+- If an array is checked not to be empty by [isNonEmptyArray](https://slash.page/libraries/common/utils/src/array/isnonemptyarray.i18n), `last` returns a non-nullable value.
 
 ## Example
 

--- a/packages/common/utils/src/object/object-entries.en.md
+++ b/packages/common/utils/src/object/object-entries.en.md
@@ -5,7 +5,7 @@ sidebar_label: objectEntries
 
 # objectEntries
 
-A utility function which behaves identical to [Object.entries()](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Object/entries). It strictly infers the `key` type of an object.
+A utility function which behaves identical to [Object.entries()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries). It strictly infers the `key` type of an object.
 
 ## Example
 

--- a/packages/common/utils/src/object/object-keys.en.md
+++ b/packages/common/utils/src/object/object-keys.en.md
@@ -5,7 +5,7 @@ sidebar_label: objectKeys
 
 # objectKeys
 
-A utility function which behaves identical to [Object.keys()](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Object/keys). It strictly infers the `key` type of an object.
+A utility function which behaves identical to [Object.keys()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys). It strictly infers the `key` type of an object.
 
 ## Example
 

--- a/packages/common/utils/src/object/object-values.en.md
+++ b/packages/common/utils/src/object/object-values.en.md
@@ -5,7 +5,7 @@ sidebar_label: objectValues
 
 # objectValues
 
-A function which behaves identical to [Object.values()](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Object/values).
+A function which behaves identical to [Object.values()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values).
 
 ## Example
 

--- a/packages/react/impression-area/src/ImpressionArea.en.md
+++ b/packages/react/impression-area/src/ImpressionArea.en.md
@@ -5,7 +5,7 @@ title: ImpressionArea
 # ImpressionArea
 
 A component that fires an event when it appears or disappears in the browser viewport.
-It uses the [IntersectionObserver](https://developer.mozilla.org/ko/docs/Web/API/Intersection_Observer_API) API to work efficiently.
+It uses the [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) API to work efficiently.
 
 ImpressionArea renders an additional div. (If you don't need a div, use the `useImpressionRef` Hook).
 

--- a/packages/react/impression-area/src/useImpressionRef.en.md
+++ b/packages/react/impression-area/src/useImpressionRef.en.md
@@ -5,7 +5,7 @@ title: useImpressionRef
 # useImpressionRef
 
 Hook that fires an event when the element given by `ref` appears or disappears in the browser viewport.
-It works efficiently by using the [IntersectionObserver](https://developer.mozilla.org/ko/docs/Web/API/Intersection_Observer_API) API.
+It works efficiently by using the [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) API.
 
 To use it as a component, use `ImpressionArea`.
 


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

Update the links linked to Korean documents in English docs correctly.

<img width="444" alt="image" src="https://github.com/toss/slash/assets/57122180/032fa609-620a-46e4-a783-207b79776b54">


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
