### PR TITLE
fix(@toss/react): Change the useBooleanState hook return value data type

### DIFF
--- a/packages/react/lottie/src/Lottie.tsx
+++ b/packages/react/lottie/src/Lottie.tsx
@@ -108,7 +108,7 @@ export const Lottie = forwardRef(function Lottie(
   const containerRef = useRef<HTMLDivElement>(null);
   const animationChainRef = useRef<AnimationChain | null>(null);
 
-  const [isVisible, handleImpressionStart] = useBooleanState(false);
+  const { bool: isVisible, setTrue: handleImpressionStart } = useBooleanState(false);
 
   const isFirstPlayRef = useRef<boolean>(true);
 

--- a/packages/react/react/src/hooks/useBooleanState.en.md
+++ b/packages/react/react/src/hooks/useBooleanState.en.md
@@ -3,11 +3,21 @@
 A hook that makes it easy to use useState as a boolean type.
 
 ```ts
-function useBooleanState(defaultValue = false): readonly [bool, setTrue, setFalse, toggle];
+function useBooleanState(defaultValue = false): {
+  readonly bool: boolean;
+  readonly setTrue: () => void;
+  readonly setFalse: () => void;
+  readonly toggle: () => void;
+};
 ```
 
 ## Example
 
 ```ts
-const [open, openBottomSheet, closeBottomSheet, toggleBottomSheet] = useBooleanState(false);
+const {
+  bool: open,
+  setTrue: openBottomSheet,
+  setFalse: closeBottomSheet,
+  toggle: toggleBottomSheet,
+} = useBooleanState(false);
 ```

--- a/packages/react/react/src/hooks/useBooleanState.ko.md
+++ b/packages/react/react/src/hooks/useBooleanState.ko.md
@@ -3,11 +3,21 @@
 boolean 타입으로 useState를 쉽게 사용할 수 있는 hook 입니다.
 
 ```ts
-function useBooleanState(defaultValue = false): readonly [bool, setTrue, setFalse, toggle];
+function useBooleanState(defaultValue = false): {
+  readonly bool: boolean;
+  readonly setTrue: () => void;
+  readonly setFalse: () => void;
+  readonly toggle: () => void;
+};
 ```
 
 ## Example
 
 ```ts
-const [open, openBottomSheet, closeBottomSheet, toggleBottomSheet] = useBooleanState(false);
+const {
+  bool: open,
+  setTrue: openBottomSheet,
+  setFalse: closeBottomSheet,
+  toggle: toggleBottomSheet,
+} = useBooleanState(false);
 ```

--- a/packages/react/react/src/hooks/useBooleanState.spec.ts
+++ b/packages/react/react/src/hooks/useBooleanState.spec.ts
@@ -6,7 +6,7 @@ describe('`useBooleanState`', () => {
   describe('반환 값 타입 체크', () => {
     const { result } = renderHook(useBooleanState);
 
-    const [bool, setTrue, setFalse] = result.current;
+    const { bool, setTrue, setFalse } = result.current;
 
     it('bool의 타입은 boolean이다.', () => {
       expect(typeof bool).toBe('boolean');
@@ -24,21 +24,21 @@ describe('`useBooleanState`', () => {
   describe('초기값 체크', () => {
     it('디폴트 인자는 false로 반환값은 false이다.', () => {
       const { result } = renderHook(useBooleanState);
-      const [bool] = result.current;
+      const { bool } = result.current;
 
       expect(bool).toBe(false);
     });
 
     it('인자가 false면 반환값도 false이다.', () => {
       const { result } = renderHook(() => useBooleanState(false));
-      const [bool] = result.current;
+      const { bool } = result.current;
 
       expect(bool).toBe(false);
     });
 
     it('인자가 true면 반환값도 true이다.', () => {
       const { result } = renderHook(() => useBooleanState(true));
-      const [bool] = result.current;
+      const { bool } = result.current;
 
       expect(bool).toBe(true);
     });
@@ -47,13 +47,13 @@ describe('`useBooleanState`', () => {
   it('`setTrue` 실행 시, `bool`은 `true`가 된다.', () => {
     {
       const { result } = renderHook(() => useBooleanState(false));
-      const [, setTrue] = result.current;
+      const { setTrue } = result.current;
 
       act(() => {
         setTrue();
       });
 
-      const [bool] = result.current;
+      const { bool } = result.current;
 
       expect(bool).toBe(true);
     }
@@ -62,13 +62,13 @@ describe('`useBooleanState`', () => {
   it('`setFalse` 실행 시, `bool`은 `false`가 된다.', () => {
     {
       const { result } = renderHook(() => useBooleanState(true));
-      const [, , setFalse] = result.current;
+      const { setFalse } = result.current;
 
       act(() => {
         setFalse();
       });
 
-      const [bool] = result.current;
+      const { bool } = result.current;
 
       expect(bool).toBe(false);
     }
@@ -76,12 +76,12 @@ describe('`useBooleanState`', () => {
 
   it('`toggle` 실행 시, `bool`은 `true` -> `false`, `false` -> `true`가 된다.', () => {
     const { result } = renderHook(() => useBooleanState(true));
-    const [, , , toggle] = result.current;
+    const { toggle } = result.current;
 
     {
       act(toggle);
 
-      const [bool] = result.current;
+      const { bool } = result.current;
 
       expect(bool).toBe(false);
     }
@@ -89,7 +89,7 @@ describe('`useBooleanState`', () => {
     {
       act(toggle);
 
-      const [bool] = result.current;
+      const { bool } = result.current;
 
       expect(bool).toBe(true);
     }
@@ -97,7 +97,7 @@ describe('`useBooleanState`', () => {
     {
       act(toggle);
 
-      const [bool] = result.current;
+      const { bool } = result.current;
 
       expect(bool).toBe(false);
     }

--- a/packages/react/react/src/hooks/useBooleanState.ts
+++ b/packages/react/react/src/hooks/useBooleanState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 /** @tossdocs-ignore */
-export const useBooleanState = (defaultValue = false): readonly [boolean, () => void, () => void, () => void] => {
+export const useBooleanState = (defaultValue = false) => {
   const [bool, setBool] = useState(defaultValue);
 
   const setTrue = useCallback(() => {
@@ -16,5 +16,5 @@ export const useBooleanState = (defaultValue = false): readonly [boolean, () => 
     setBool(b => !b);
   }, []);
 
-  return [bool, setTrue, setFalse, toggle] as const;
+  return { bool, setTrue, setFalse, toggle } as const;
 };


### PR DESCRIPTION
## Overview
- `useBooleanState` 훅이 반환하는 데이터를 배열에서 객체로 타입을 변경을 진행해봤습니다.
- 기존의 useBooleanState를 사용할 때는 반환 데이터가 `배열(length: 4)`이라 실제 사용하지 않는 요소가 있을 때 불편한 부분이 있습니다.
  - 예를 들어, 아래 예제는 useBooleanState의 첫번째 요소인 bool과 마지막 요소인 toggle만을 활용한다고 가정했을 때 입니다.
```js
// as-is
const [bool, , , toggle] = useBooleanState();
```
- 이를, 객체로 변경함으로써 굳이 마지막 요소인 toggle을 위해 불 필요한 `[, ,]` 를 하지 않고, 필요한 요소만 가져와서 사용할 수 있게끔 수정 작업을 진행했습니다.
```js
// to-be
const { bool, setFalse, toggle } = useBooleanState();
```
- 검토 후에 피드백 부탁드립니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
