### PR TITLE
feat(@toss/react): add useActionObserver Hook

### DIFF
--- a/packages/react/react/src/hooks/index.ts
+++ b/packages/react/react/src/hooks/index.ts
@@ -1,4 +1,5 @@
 /** @tossdocs-ignore */
+export * from './useActionObserver';
 export * from './useBodyClass';
 export * from './useBooleanState';
 export * from './useCallbackOnce';

--- a/packages/react/react/src/hooks/useActionObserver.en.md
+++ b/packages/react/react/src/hooks/useActionObserver.en.md
@@ -18,7 +18,7 @@ function useActionObserver<E extends HTMLElement = HTMLElement>({
   threshold,
   rootMargin,
   repetitionCount,
-  root = null,
+  root,
 }: UseActionObserverProps): EffectRef<E>;
 ```
 

--- a/packages/react/react/src/hooks/useActionObserver.en.md
+++ b/packages/react/react/src/hooks/useActionObserver.en.md
@@ -1,6 +1,6 @@
 ## useActionObserver
 
-The useActionObserver hook is a Hook that associates the "ref" that it returns with a specific Element, causing the "onAction" function to be called when that Element is exposed to the "Viewport" a "threshold" amount of times while subscribing to the "IntersectionObserver".
+The useActionObserver hook returns a "ref" that can be connected to a specific element. When the element subscribes to the Intersection Observer and is exposed to the "Viewport" by a certain "threshold", the hook calls the "onAction" function.
 
 The useActionObserver hook optionally takes in the basic options for "IntersectionObserver" (threshold, rootMargin, root), and you can use repetitionCount to specify how many times you want to call onAction.
 

--- a/packages/react/react/src/hooks/useActionObserver.en.md
+++ b/packages/react/react/src/hooks/useActionObserver.en.md
@@ -1,0 +1,49 @@
+## useActionObserver
+
+The useActionObserver hook is a Hook that associates the "ref" that it returns with a specific Element, causing the "onAction" function to be called when that Element is exposed to the "Viewport" a "threshold" amount of times while subscribing to the "IntersectionObserver".
+
+The useActionObserver hook optionally takes in the basic options for "IntersectionObserver" (threshold, rootMargin, root), and you can use repetitionCount to specify how many times you want to call onAction.
+
+```ts
+interface UseActionObserverProps {
+  onAction: () => void;
+  threshold?: number | number[];
+  root?: Document | Element | null;
+  rootMargin?: string;
+  repetitionCount?: number;
+}
+
+function useActionObserver<E extends HTMLElement = HTMLElement>({
+  onAction,
+  threshold,
+  rootMargin,
+  repetitionCount,
+  root = null,
+}: UseActionObserverProps): EffectRef<E>;
+```
+
+## Example
+
+```jsx
+const Example = () => {
+  const box1Ref = useActionObserver({
+    onAction: () => {
+      console.log('The onAction function is executed when the component is exposed in the Viewport by 0.3 (30%)');
+    },
+    threshold: 0.3,
+  });
+  const box2Ref = useActionObserver({
+    onAction: () => console.log('After the onAction function is called 3 times, unobserve box2'),
+    repetitionCount: 3,
+  });
+  const box3Ref = useActionObserver({ onAction: () => console.log('Default Example') });
+
+  return (
+    <div>
+      <Box ref={box1Ref}>Example Box1</Box>
+      <Box ref={box2Ref}>Example Box2</Box>
+      <Box ref={box3Ref}>Example Box3</Box>
+    </div>
+  );
+};
+```

--- a/packages/react/react/src/hooks/useActionObserver.ko.md
+++ b/packages/react/react/src/hooks/useActionObserver.ko.md
@@ -18,7 +18,7 @@ function useActionObserver<E extends HTMLElement = HTMLElement>({
   threshold,
   rootMargin,
   repetitionCount,
-  root = null,
+  root,
 }: UseActionObserverProps): EffectRef<E>;
 ```
 

--- a/packages/react/react/src/hooks/useActionObserver.ko.md
+++ b/packages/react/react/src/hooks/useActionObserver.ko.md
@@ -1,0 +1,47 @@
+## useActionObserver
+
+useActionObserver hook은 해당 hook이 반환하는 "ref"를 특정 Element에 연결하여, 해당 Element가 "IntersectionObserver" 구독하면서 "Viewport"에 "threshold"만큼 노출되면 "onAction" 함수를 호출하게 만드는 Hook입니다.
+
+useActionObserver hook은 "IntersectionObserver"의 기본적인 옵션(threshold, rootMargin, root)을 옵셔널하게 받아오며, repetitionCount를 활용하여 onAction을 얼마나 반복 호출할 것인지를 지정할 수 있습니다.
+
+```ts
+interface UseActionObserverProps {
+  onAction: () => void;
+  threshold?: number | number[];
+  root?: Document | Element | null;
+  rootMargin?: string;
+  repetitionCount?: number;
+}
+
+function useActionObserver<E extends HTMLElement = HTMLElement>({
+  onAction,
+  threshold,
+  rootMargin,
+  repetitionCount,
+  root = null,
+}: UseActionObserverProps): EffectRef<E>;
+```
+
+## Example
+
+```jsx
+const Example = () => {
+  const box1Ref = useActionObserver({
+    onAction: () => console.log('Viewport에 해당 컴포넌트가 0.3(30%)만큼 노출되면 onAction 함수가 실행되요.'),
+    threshold: 0.3,
+  });
+  const box2Ref = useActionObserver({
+    onAction: () => console.log('onAction 함수가 3회 호출되면, box2를 unobserve해요.'),
+    repetitionCount: 3,
+  });
+  const box3Ref = useActionObserver({ onAction: () => console.log('Default Example') });
+
+  return (
+    <div>
+      <Box ref={box1Ref}>Example Box1</Box>
+      <Box ref={box2Ref}>Example Box2</Box>
+      <Box ref={box3Ref}>Example Box3</Box>
+    </div>
+  );
+};
+```

--- a/packages/react/react/src/hooks/useActionObserver.ko.md
+++ b/packages/react/react/src/hooks/useActionObserver.ko.md
@@ -1,6 +1,6 @@
 ## useActionObserver
 
-useActionObserver hook은 해당 hook이 반환하는 "ref"를 특정 Element에 연결하여, 해당 Element가 "IntersectionObserver" 구독하면서 "Viewport"에 "threshold"만큼 노출되면 "onAction" 함수를 호출하게 만드는 Hook입니다.
+useActionObserver hook은 반환하는 "ref"를 특정 Element에 연결하여, 해당 Element가 Intersection Observer 구독하면서, "Viewport"에 "threshold"만큼 노출되면 "onAction" 함수를 호출하는 hook입니다.
 
 useActionObserver hook은 "IntersectionObserver"의 기본적인 옵션(threshold, rootMargin, root)을 옵셔널하게 받아오며, repetitionCount를 활용하여 onAction을 얼마나 반복 호출할 것인지를 지정할 수 있습니다.
 

--- a/packages/react/react/src/hooks/useActionObserver.tsx
+++ b/packages/react/react/src/hooks/useActionObserver.tsx
@@ -12,10 +12,10 @@ interface UseActionObserverProps {
 /** @tossdocs-ignore */
 export function useActionObserver<E extends HTMLElement = HTMLElement>({
   onAction,
+  repetitionCount,
   threshold,
   rootMargin,
-  repetitionCount,
-  root = null,
+  root,
 }: UseActionObserverProps) {
   const actionCallback = usePreservedCallback(onAction);
   const ref = useRefEffect<E>(
@@ -29,9 +29,11 @@ export function useActionObserver<E extends HTMLElement = HTMLElement>({
             return;
           }
 
-          if (entry.isIntersecting) {
-            callCount++;
-            actionCallback();
+          if (entry != null) {
+            if (entry.isIntersecting) {
+              callCount++;
+              actionCallback();
+            }
           }
         },
         {

--- a/packages/react/react/src/hooks/useActionObserver.tsx
+++ b/packages/react/react/src/hooks/useActionObserver.tsx
@@ -1,0 +1,53 @@
+import { usePreservedCallback } from './usePreservedCallback';
+import { useRefEffect } from './useRefEffect';
+
+interface UseActionObserverProps {
+  onAction: () => void;
+  threshold?: number | number[];
+  root?: Document | Element | null;
+  rootMargin?: string;
+  repetitionCount?: number;
+}
+
+/** @tossdocs-ignore */
+export function useActionObserver<E extends HTMLElement = HTMLElement>({
+  onAction,
+  threshold,
+  rootMargin,
+  repetitionCount,
+  root = null,
+}: UseActionObserverProps) {
+  const actionCallback = usePreservedCallback(onAction);
+  const ref = useRefEffect<E>(
+    elem => {
+      let callCount = 0;
+
+      const observer = new IntersectionObserver(
+        ([entry]: IntersectionObserverEntry[]) => {
+          if (repetitionCount != null && repetitionCount <= callCount) {
+            observer.unobserve(elem);
+            return;
+          }
+
+          if (entry.isIntersecting) {
+            callCount++;
+            actionCallback();
+          }
+        },
+        {
+          threshold,
+          root,
+          rootMargin,
+        }
+      );
+      observer.observe(elem);
+
+      return () => {
+        observer.unobserve(elem);
+      };
+    },
+    [actionCallback]
+  );
+
+  return ref;
+}


### PR DESCRIPTION
## Overview

I worked on the `useActionObserver` hook, which has a similar concept to the `useResizeObserver` hook.

This hook connects the returned "ref" to a specific Element, subscribes the Element to the Intersection Observer, and calls the onAction function when the Element is exposed to the threshold in the Viewport.

Please provide feedback after review.

## Demo Video
https://github.com/ssi02014/react-step-parallax/assets/64779472/36321f46-1b4b-4417-a217-06199211af8e

## Demo Code
```jsx
const Example = () => {
  const box1 = useActionObserver({
    onAction: () => console.log('box1 onAction 호출'),
    repetitionCount: 3,
  });
  const box2 = useActionObserver({
    onAction: () => console.log('box2 onAction 호출'),
  });
  const box3 = useActionObserver({
    onAction: () => console.log('box3 onAction 호출'),
  });
  const box4 = useActionObserver({
    onAction: () => console.log('box4 onAction 호출'),
  });

  return (
    <div>
      <Box ref={box1}>
        <h1>Example Box1</h1>
      </Box>
      <Box ref={box2}>
        <h1>Example Box2</h1>
      </Box>
      <Box ref={box3}>
        <h1>Example Box3</h1>
      </Box>
      <Box ref={box4}>
        <h1>Example Box4</h1>
      </Box>
    </div>
  );
};
```

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
