### PR TITLE
docs(@toss/error-boundary): split `withErrorBoundaryGroup` HOC to file with docs

### DIFF
--- a/packages/react/error-boundary/src/ErrorBoundaryGroup.tsx
+++ b/packages/react/error-boundary/src/ErrorBoundaryGroup.tsx
@@ -1,7 +1,6 @@
 /** @tossdocs-ignore */
-import { ComponentType, createContext, ReactNode, useContext, useEffect, useMemo, useRef } from 'react';
+import { createContext, ReactNode, useContext, useEffect, useMemo, useRef } from 'react';
 import { useIsMounted, useKey } from './hooks';
-import { ComponentPropsWithoutChildren } from './types';
 
 export const ErrorBoundaryGroupContext = createContext<{ reset: () => void; resetKey: number } | undefined>(undefined);
 if (process.env.NODE_ENV !== 'production') {
@@ -74,22 +73,4 @@ export const useErrorBoundaryGroup = () => {
     }),
     [group.reset]
   );
-};
-
-export const withErrorBoundaryGroup = <Props extends Record<string, unknown> = Record<string, never>>(
-  Component: ComponentType<Props>,
-  errorBoundaryGroupProps?: ComponentPropsWithoutChildren<typeof ErrorBoundaryGroup>
-) => {
-  const Wrapped = (props: Props) => (
-    <ErrorBoundaryGroup {...errorBoundaryGroupProps}>
-      <Component {...props} />
-    </ErrorBoundaryGroup>
-  );
-
-  if (process.env.NODE_ENV !== 'production') {
-    const name = Component.displayName || Component.name || 'Component';
-    Wrapped.displayName = `withErrorBoundaryGroup(${name})`;
-  }
-
-  return Wrapped;
 };

--- a/packages/react/error-boundary/src/index.ts
+++ b/packages/react/error-boundary/src/index.ts
@@ -1,3 +1,4 @@
 /** @tossdocs-ignore */
 export { ErrorBoundary, useErrorBoundary, withErrorBoundary } from './ErrorBoundary';
-export { ErrorBoundaryGroup, useErrorBoundaryGroup, withErrorBoundaryGroup } from './ErrorBoundaryGroup';
+export { ErrorBoundaryGroup, useErrorBoundaryGroup } from './ErrorBoundaryGroup';
+export { withErrorBoundaryGroup } from './withErrorBoundaryGroup';

--- a/packages/react/error-boundary/src/withErrorBoundaryGroup.en.md
+++ b/packages/react/error-boundary/src/withErrorBoundaryGroup.en.md
@@ -1,0 +1,16 @@
+---
+title: withErrorBoundaryGroup
+---
+
+# withErrorBoundaryGroup
+
+Higher-order component that wraps the given component in an `ErrorBoundaryGroup`.
+See the documentation for [ErrorBoundaryGroup](https://slash.page/libraries/react/error-boundary/src/errorboundarygroup.i18n) for detailed usage.
+
+## Examples
+
+```jsx
+const MyComponent = withErrorBoundaryGroup(Has_Multiple_ErrorBoundary_Compoonent, {
+  blockOutside: true,
+});
+```

--- a/packages/react/error-boundary/src/withErrorBoundaryGroup.ko.md
+++ b/packages/react/error-boundary/src/withErrorBoundaryGroup.ko.md
@@ -1,0 +1,16 @@
+---
+title: withErrorBoundaryGroup
+---
+
+# withErrorBoundaryGroup
+
+주어진 컴포넌트를 `ErrorBoundaryGroup`로 감싸는 Higher-order component 입니다.
+자세한 사용법은 [ErrorBoundaryGroup](https://slash.page/ko/libraries/react/error-boundary/src/ErrorBoundaryGroup.i18n) 에 대한 문서를 참조하세요.
+
+## Examples
+
+```jsx
+const MyComponent = withErrorBoundaryGroup(여러_ErrorBoundary가_포함된_컴포넌트, {
+  blockOutside: true,
+});
+```

--- a/packages/react/error-boundary/src/withErrorBoundaryGroup.tsx
+++ b/packages/react/error-boundary/src/withErrorBoundaryGroup.tsx
@@ -1,0 +1,21 @@
+import { ComponentType } from 'react';
+import { ErrorBoundaryGroup } from './ErrorBoundaryGroup';
+import { ComponentPropsWithoutChildren } from './types';
+
+export const withErrorBoundaryGroup = <Props extends Record<string, unknown> = Record<string, never>>(
+  Component: ComponentType<Props>,
+  errorBoundaryGroupProps?: ComponentPropsWithoutChildren<typeof ErrorBoundaryGroup>
+) => {
+  const Wrapped = (props: Props) => (
+    <ErrorBoundaryGroup {...errorBoundaryGroupProps}>
+      <Component {...props} />
+    </ErrorBoundaryGroup>
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    const name = Component.displayName || Component.name || 'Component';
+    Wrapped.displayName = `withErrorBoundaryGroup(${name})`;
+  }
+
+  return Wrapped;
+};


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I split `withErrorBoundaryGroup` HOC to file like as [withAsyncBoundary](https://slash.page/libraries/react/async-boundary/src/withAsyncBoundary.i18n)

<img width="307" alt="image" src="https://github.com/toss/slash/assets/57122180/604aa7d8-8be2-4726-ad64-31cfb9c607bd">


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
