### PR TITLE
docs(docs): add colorMode to config file

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,7 +45,7 @@ module.exports = {
       },
     },
   },
-  themeConfig: {
+  themeConfig: /** @type {import('@docusaurus/preset-classic').ThemeConfig} */ ({
     navbar: {
       title: 'Slash libraries',
       logo: {
@@ -99,6 +99,9 @@ module.exports = {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
     },
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     algolia: {
       appId: '5HUNJYWIP5',
       apiKey: '7deeee6b4d09217c1dff5ff279561bf4',
@@ -107,7 +110,7 @@ module.exports = {
       branch: 'main',
       contextualSearch: true,
     },
-  },
+  }),
   plugins: [require.resolve('./scripts/webpack5-compat.js')],
   presets: [
     [


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I add color scheme config to docusaurus.config.js 

Using user system preferences, instead of the hardcoded ([referece](https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme))

https://github.com/toss/slash/assets/57122180/4322cf63-e738-4d7d-8dd3-0db3f1839fa5


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
