### PR TITLE
feat(@toss/utils): add type overloading on createMapByKey function (be able to get readonly parameter)

### DIFF
--- a/packages/common/utils/src/createMapByKey.ts
+++ b/packages/common/utils/src/createMapByKey.ts
@@ -2,6 +2,16 @@
 export function createMapByKey<Entity, KeyName extends keyof Entity>(
   objects: Entity[],
   key: KeyName
+): Map<Entity[KeyName], Entity>;
+
+export function createMapByKey<Entity, KeyName extends keyof Entity>(
+  objects: readonly Entity[],
+  key: KeyName
+): Map<Entity[KeyName], Entity>;
+
+export function createMapByKey<Entity, KeyName extends keyof Entity>(
+  objects,
+  key
 ): Map<Entity[KeyName], Entity> {
   type KeyType = Entity[KeyName];
 


### PR DESCRIPTION
add type overloading on createMapByKey function (be able to get readonly parameter)

## Overview

`slonik` 등 Database로부터 readonly 타입을 반환하는 쿼리빌더에서 기존 `@toss/utils`의 `createMapByKey` 함수를 사용할 수 없었음.
readonly에 대한 타입 오버로딩을 추가하여 해결.

## PR Checklist

- [x ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
