### PR TITLE
fix(@toss/react): literal type inference

### DIFF
--- a/packages/react/react/src/hooks/useStorageState.spec.ts
+++ b/packages/react/react/src/hooks/useStorageState.spec.ts
@@ -141,7 +141,7 @@ function createMockStorage() {
   };
 }
 
-function createFixture<T extends Serializable>({ defaultValue }: { defaultValue?: T } = {}) {
+function createFixture<T>({ defaultValue }: { defaultValue?: Serializable<T> } = {}) {
   const key = '@@test-key';
   const storage = createMockStorage();
   const render = () => renderHook(() => useStorageState<T>(key, { storage, defaultValue }));

--- a/packages/react/react/src/hooks/useStorageState.ts
+++ b/packages/react/react/src/hooks/useStorageState.ts
@@ -2,35 +2,39 @@
 import { safeLocalStorage, Storage } from '@toss/storage';
 import { SetStateAction, useCallback, useState } from 'react';
 
-export type Serializable = string | number | boolean | unknown[] | Record<string, unknown>;
+type ToPrimitive<T> = T extends string ? string : T extends number ? number : T extends boolean ? boolean : never;
+type ToObject<T> = T extends unknown[] | Record<string, unknown> ? T : never;
+
+export type Serializable<T> = T extends string | number | boolean ? ToPrimitive<T> : ToObject<T>;
+
 interface StorageStateOptions<T> {
   storage?: Storage;
-  defaultValue?: T;
+  defaultValue?: Serializable<T>;
 }
 
 interface StorageStateOptionsWithDefaultValue<T> extends StorageStateOptions<T> {
-  defaultValue: T;
+  defaultValue: Serializable<T>;
 }
 
 /**
  * 스토리지에 상태값을 저장하고 불러와서 값이 보존되는 useState로 동작하는 hook입니다.
  * @param key 스토리지에 저장할 키
  */
-export function useStorageState<T extends Serializable>(
+export function useStorageState<T>(
   key: string
-): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void];
-export function useStorageState<T extends Serializable>(
+): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void, () => void];
+export function useStorageState<T>(
   key: string,
   { storage, defaultValue }: StorageStateOptionsWithDefaultValue<T>
-): readonly [T, (value: SetStateAction<T>) => void, () => void];
-export function useStorageState<T extends Serializable>(
+): readonly [Serializable<T>, (value: SetStateAction<Serializable<T>>) => void, () => void];
+export function useStorageState<T>(
   key: string,
   { storage, defaultValue }: StorageStateOptions<T>
-): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void];
-export function useStorageState<T extends Serializable>(
+): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void, () => void];
+export function useStorageState<T>(
   key: string,
   { storage = safeLocalStorage, defaultValue }: StorageStateOptions<T> = {}
-): readonly [T | undefined, (value: SetStateAction<T | undefined>) => void, () => void] {
+): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void, () => void] {
   const getValue = useCallback(<T>() => {
     const data = storage.get(key);
 
@@ -52,10 +56,10 @@ export function useStorageState<T extends Serializable>(
     }
   }, [defaultValue, key, storage]);
 
-  const [state, setState] = useState<T | undefined>(getValue);
+  const [state, setState] = useState<Serializable<T> | undefined>(getValue);
 
   const set = useCallback(
-    (value: SetStateAction<T | undefined>) => {
+    (value: SetStateAction<Serializable<T> | undefined>) => {
       setState(curr => {
         const nextValue = typeof value === 'function' ? value(curr) : value;
 


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

#220 

**I wrote a PR by modifying the type for `defaultValue` so that `generic` is not forced.**

TypeScript will infer **"a concrete type"** if there is a `generic type constraint` for a `primitive type`.
`Type constraint` is applied to `useStorageState` so that only values that can be serialized as `JSON` can be received as `defaultValue`.

However, if `defaultValue` was set as a `primitive type`, the `state` was inferred to be a `literal type`, and `generic` had to be created in the following situations.
```ts
// No Generic
  const [state, setState, refresh] = useStorageState('key', {
    defaultValue: 0,
  });

  useEffect(() => {
    setState(x => x + 1);
    // ^ type error
  }, []);

// Using Generic
  const [state, setState, refresh] = useStorageState<number>('key', {
    defaultValue: 0,
  });

  useEffect(() => {
    setState(x => x + 1); // No Error
  }, []);
```

### How To Fix
**The `Serializable` type was inferred by dividing it into a `primitive type` and an `object type`.**
`Primitive types` must be inferred as `primitive types`, **not `literal types`** (See `ToPrimitive<T>`), and `object types` are shallowly inferred, so it's okay to infer `T` when `true` for a conditional type (See `ToObject<T>`).
```ts
type ToPrimitive<T> = T extends string ? string : T extends number ? number : T extends boolean ? boolean : never;
type ToObject<T> = T extends unknown[] | Record<string, unknown> ? T : never;
export type Serializable<T> = T extends string | number | boolean ? ToPrimitive<T> : ToObject<T>;
```

p.s. Tried to solve this PR #223 as well, but `state` was still inferred as a `literal type`.

### AS-IS
```ts
// Need generic
  const [state, setState, refresh] = useStorageState('@service/some-resource', {
    defaultValue: 0,
  });

  state; // 0
```
### TO-BE
```ts
// No using generic
  const [state, setState, refresh] = useStorageState('@service/some-resource', {
    defaultValue: 0,
  });

  state; // number
```
## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
