### PR TITLE
fix(@toss/react): fix useOutsideClickEffect hook

### DIFF
--- a/packages/react/react/src/hooks/useOutsideClickEffect.spec.tsx
+++ b/packages/react/react/src/hooks/useOutsideClickEffect.spec.tsx
@@ -21,7 +21,7 @@ describe('useOutsideClickEffect', () => {
 
       const updateContainer = useCallback((elem: HTMLDivElement | null) => {
         if (elem != null) {
-          setContainers(containers => [...containers, { current: elem }]);
+          setContainers(prev => [...prev, { current: elem }]);
         }
       }, []);
 

--- a/packages/react/react/src/hooks/useOutsideClickEffect.spec.tsx
+++ b/packages/react/react/src/hooks/useOutsideClickEffect.spec.tsx
@@ -16,12 +16,12 @@ describe('useOutsideClickEffect', () => {
 
   function prepare({ containerCount = 1, onEffect = jest.fn() }: PrepareParams = {}) {
     function Test() {
-      const [containers, setContainers] = useState<HTMLDivElement[]>([]);
+      const [containers, setContainers] = useState<Array<React.RefObject<HTMLElement>>>([]);
       useOutsideClickEffect(containers, onEffect);
 
       const updateContainer = useCallback((elem: HTMLDivElement | null) => {
         if (elem != null) {
-          setContainers(prev => [...prev, elem]);
+          setContainers(containers => [...containers, { current: elem }]);
         }
       }, []);
 

--- a/packages/react/react/src/hooks/useOutsideClickEffect.ts
+++ b/packages/react/react/src/hooks/useOutsideClickEffect.ts
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useRef } from 'react';
 type OneOrMore<T> = T | T[];
 
 /** @tossdocs-ignore */
-export function useOutsideClickEffect(container: OneOrMore<HTMLElement | null>, callback: () => void) {
-  const containers = useRef<HTMLElement[]>([]);
+export function useOutsideClickEffect(container: OneOrMore<React.RefObject<HTMLElement> | null>, callback: () => void) {
+  const containers = useRef<Array<React.RefObject<HTMLElement>>>([]);
 
   useEffect(() => {
     containers.current = (Array.isArray(container) ? container : [container]).filter(isNotNil);
@@ -21,7 +21,7 @@ export function useOutsideClickEffect(container: OneOrMore<HTMLElement | null>, 
         return;
       }
 
-      if (containers.current.some(x => x.contains(target as Node))) {
+      if (containers.current.some(x => x.current?.contains(target as Node))) {
         return;
       }
 


### PR DESCRIPTION
## Overview

FIX #293 

Fix useOutsideClickEffect hook by changing factor 'container' and local state 'containers'

```js
AS-IS
useOutsideClickEffect(container: OneOrMore<HTMLElement | null>, callback: () => void)

const [containers, setContainers] = useState<HTMLElement[]>([]);

TO-BE
useOutsideClickEffect(container: OneOrMore<React.RefObject<HTMLElement> | null>, callback: () => void)

const [containers, setContainers] = useState<Array<React.RefObject<HTMLElement>>>([]);
```

```js
const ref = useRef<HTMLElement>(null);

// works!
useOutsideClickEffect(ref, () => {
  console.log('outside clicked!');
});
```



## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
