### PR TITLE
chore(@toss/react):  change wrong variable names in `useTimeoutQueue` test code

### DIFF
--- a/packages/react/react/src/hooks/useTimeoutQueue.spec.ts
+++ b/packages/react/react/src/hooks/useTimeoutQueue.spec.ts
@@ -31,10 +31,10 @@ describe('useTimeoutQueue는', () => {
   });
 
   it('실행되지 않은 Task는 안전하게 clear 된다.', () => {
-    const TEST_INTERVAL_ID = 3302;
+    const TEST_TIMEOUT_ID = 3302;
 
     const setIntervalMock: any = () => {
-      return TEST_INTERVAL_ID;
+      return TEST_TIMEOUT_ID;
     };
     jest.spyOn(window, 'setTimeout').mockImplementation(setIntervalMock);
 
@@ -49,6 +49,6 @@ describe('useTimeoutQueue는', () => {
     unmount();
 
     expect(clearIntervalMock).toBeCalledTimes(1);
-    expect(clearIntervalMock).toBeCalledWith(TEST_INTERVAL_ID);
+    expect(clearIntervalMock).toBeCalledWith(TEST_TIMEOUT_ID);
   });
 });

--- a/packages/react/react/src/hooks/useTimeoutQueue.spec.ts
+++ b/packages/react/react/src/hooks/useTimeoutQueue.spec.ts
@@ -33,12 +33,12 @@ describe('useTimeoutQueue는', () => {
   it('실행되지 않은 Task는 안전하게 clear 된다.', () => {
     const TEST_TIMEOUT_ID = 3302;
 
-    const setIntervalMock: any = () => {
+    const setTimeoutMock: any = () => {
       return TEST_TIMEOUT_ID;
     };
-    jest.spyOn(window, 'setTimeout').mockImplementation(setIntervalMock);
+    jest.spyOn(window, 'setTimeout').mockImplementation(setTimeoutMock);
 
-    const clearIntervalMock = jest.spyOn(window, 'clearTimeout');
+    const clearTimeoutMock = jest.spyOn(window, 'clearTimeout');
 
     const { result, unmount } = renderHook(useTimeoutQueue);
     const timeouts = result.current;
@@ -48,7 +48,7 @@ describe('useTimeoutQueue는', () => {
 
     unmount();
 
-    expect(clearIntervalMock).toBeCalledTimes(1);
-    expect(clearIntervalMock).toBeCalledWith(TEST_TIMEOUT_ID);
+    expect(clearTimeoutMock).toBeCalledTimes(1);
+    expect(clearTimeoutMock).toBeCalledWith(TEST_TIMEOUT_ID);
   });
 });


### PR DESCRIPTION
## Overview

Change wrong variable names in `@toss/react/useTimeoutQueue` test code.
Because setTimeout returns timeout id, not interval id.

## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
