### PR TITLE
test(@toss/react): Add usePreservedReference Test Code

### DIFF
--- a/packages/react/react/src/hooks/usePreservedReference.spec.tsx
+++ b/packages/react/react/src/hooks/usePreservedReference.spec.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { usePreservedReference } from './usePreservedReference';
+
+describe('usePreservedReference', () => {
+  it('should return the initial value', () => {
+    const initialValue = { name: 'toss' };
+
+    const { result } = renderHook(({ value }) => usePreservedReference(value), {
+      initialProps: { value: initialValue },
+    });
+
+    expect(result.current).toBe(initialValue);
+  });
+
+  it('should return the original reference if areDeeplyEqual returns true', () => {
+    const initialValue = { name: 'toss' };
+
+    const { result, rerender } = renderHook(({ value }) => usePreservedReference(value), {
+      initialProps: { value: initialValue },
+    });
+
+    rerender({ value: { name: 'toss' } });
+    expect(result.current).toBe(initialValue);
+  });
+
+  it('should return the new reference if areDeeplyEqual returns false', () => {
+    const initialValue = { name: 'toss' };
+    const newValue = { name: 'react' };
+
+    const { result, rerender } = renderHook(({ value }) => usePreservedReference(value), {
+      initialProps: { value: initialValue },
+    });
+
+    rerender({ value: newValue });
+    expect(result.current).toBe(newValue);
+
+    rerender({ value: { name: 'react' } });
+    expect(result.current).toBe(newValue);
+  });
+
+  it('should be able to customize areValuesEqual function and return rules are same', () => {
+    const initialValue = [0, 1, 2];
+    const newValue = [1, 2, 3];
+
+    const tempComparator = (a: number[], b: number[]) => {
+      return a[0] === b[0];
+    };
+
+    const { result, rerender } = renderHook(({ value }) => usePreservedReference(value, tempComparator), {
+      initialProps: { value: initialValue },
+    });
+
+    rerender({ value: [0, 1, 4] });
+    expect(result.current).toBe(initialValue);
+
+    rerender({ value: newValue });
+    expect(result.current).toBe(newValue);
+
+    rerender({ value: [1, 4, 5] });
+    expect(result.current).toBe(newValue);
+  });
+});


### PR DESCRIPTION
## Overview

I wrote test code for a usePreservedReference that didn't exist before. 🙏

```tsx
it('should return the initial value', () => {
  const initialValue = { name: 'toss' };

  const { result } = renderHook(({ value }) => usePreservedReference(value), {
    initialProps: { value: initialValue },
  });

  expect(result.current).toBe(initialValue); // I used "toBe" because it's the same reference.
});
```

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
