### PR TITLE
test(@toss/utils): Add getViewportSize Test Code

### DIFF
--- a/packages/common/utils/src/getViewportSize.spec.tsx
+++ b/packages/common/utils/src/getViewportSize.spec.tsx
@@ -1,0 +1,30 @@
+import { getViewportSize } from './getViewportSize';
+
+const setViewportSize = (width: number, height: number) => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: height });
+};
+
+describe('getViewportSize', () => {
+  it("Jest's viewport default settings should return width 1024 and height 768", () => {
+    const { width, height } = getViewportSize();
+
+    expect(window.innerWidth).toBe(1024);
+    expect(window.innerHeight).toBe(768);
+
+    expect(width).toBe(1024);
+    expect(height).toBe(768);
+  });
+
+  it('should return width 500 and height 300', () => {
+    setViewportSize(500, 300);
+
+    const { width, height } = getViewportSize();
+
+    expect(window.innerWidth).toBe(500);
+    expect(window.innerHeight).toBe(300);
+
+    expect(width).toBe(500);
+    expect(height).toBe(300);
+  });
+});

--- a/packages/common/utils/src/getViewportSize.spec.tsx
+++ b/packages/common/utils/src/getViewportSize.spec.tsx
@@ -12,9 +12,8 @@ const deleteWindow = () => {
 };
 
 describe('getViewportSize', () => {
-  // jest sets innerWidth 1024 and innerHeight 768 as the default values for the jsdom to be tested.
   // https://github.com/jsdom/jsdom/blob/0cba358253fd5530af0685ac48c2535992464d06/lib/jsdom/browser/Window.js#L587-L588
-  it("Jest's viewport default settings should return width 1024 and height 768", () => {
+  it('should return the default width 1024 and height 768 for jsdom', () => {
     const { width, height } = getViewportSize();
 
     expect(window.innerWidth).toBe(1024);

--- a/packages/common/utils/src/getViewportSize.spec.tsx
+++ b/packages/common/utils/src/getViewportSize.spec.tsx
@@ -11,17 +11,9 @@ const deleteWindow = () => {
   });
 };
 
-const initViewportSize = () => {
+describe('getViewportSize', () => {
   // jest sets innerWidth 1024 and innerHeight 768 as the default values for the jsdom to be tested.
   // https://github.com/jsdom/jsdom/blob/0cba358253fd5530af0685ac48c2535992464d06/lib/jsdom/browser/Window.js#L587-L588
-  setViewportSize(1024, 768);
-};
-
-beforeEach(() => {
-  initViewportSize();
-});
-
-describe('getViewportSize', () => {
   it("Jest's viewport default settings should return width 1024 and height 768", () => {
     const { width, height } = getViewportSize();
 

--- a/packages/common/utils/src/getViewportSize.spec.tsx
+++ b/packages/common/utils/src/getViewportSize.spec.tsx
@@ -5,6 +5,31 @@ const setViewportSize = (width: number, height: number) => {
   Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: height });
 };
 
+const deleteWindow = () => {
+  Object.defineProperty(global, 'window', {
+    value: undefined,
+  });
+};
+
+const initViewportSize = () => {
+  // jest sets innerWidth 1024 and innerHeight 768 as the default values for the jsdom to be tested.
+  // https://github.com/jsdom/jsdom/blob/0cba358253fd5530af0685ac48c2535992464d06/lib/jsdom/browser/Window.js#L587-L588
+  setViewportSize(1024, 768);
+};
+
+beforeEach(() => {
+  initViewportSize();
+});
+
+describe('setViewportSize', () => {
+  it('should change the innerWidth to 100 and the innerHeight to 200', () => {
+    setViewportSize(100, 200);
+
+    expect(window.innerWidth).toBe(100);
+    expect(window.innerHeight).toBe(200);
+  });
+});
+
 describe('getViewportSize', () => {
   it("Jest's viewport default settings should return width 1024 and height 768", () => {
     const { width, height } = getViewportSize();
@@ -26,5 +51,16 @@ describe('getViewportSize', () => {
 
     expect(width).toBe(500);
     expect(height).toBe(300);
+  });
+
+  it('should return width 0 and height 0 if window is undefined', () => {
+    deleteWindow();
+
+    const { width, height } = getViewportSize();
+
+    expect(window).toBeUndefined();
+
+    expect(width).toBe(0);
+    expect(height).toBe(0);
   });
 });

--- a/packages/common/utils/src/getViewportSize.spec.tsx
+++ b/packages/common/utils/src/getViewportSize.spec.tsx
@@ -21,15 +21,6 @@ beforeEach(() => {
   initViewportSize();
 });
 
-describe('setViewportSize', () => {
-  it('should change the innerWidth to 100 and the innerHeight to 200', () => {
-    setViewportSize(100, 200);
-
-    expect(window.innerWidth).toBe(100);
-    expect(window.innerHeight).toBe(200);
-  });
-});
-
 describe('getViewportSize', () => {
   it("Jest's viewport default settings should return width 1024 and height 768", () => {
     const { width, height } = getViewportSize();


### PR DESCRIPTION
## Overview

I wrote a simple test code for the`getViewportSize` function in toss/utils.

### References

- [Set Size of Window in Jest](https://stackoverflow.com/questions/60396600/set-size-of-window-in-jest-and-jest-dom-and-jsdom)

```ts
Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 300 });
```

- [jsdom default Value (innerWidth: 1024, innerHeight: 768)](https://github.com/jsdom/jsdom/blob/0cba358253fd5530af0685ac48c2535992464d06/lib/jsdom/browser/Window.js#L587-L588)

<img width="681" alt="스크린샷 2023-07-30 오전 2 54 09" src="https://github.com/toss/slash/assets/64779472/7d67e512-c85e-44d0-81c0-701d86e75fd8">


## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
