### PR TITLE
fix(@toss/utils): Merge with internal `@tossteam/utils` library

### DIFF
--- a/packages/common/utils/src/object/object-keys.ts
+++ b/packages/common/utils/src/object/object-keys.ts
@@ -1,5 +1,5 @@
 /** @tossdocs-ignore */
-export type ObjectKeys<T extends Record<PropertyKey, unknown>> = Exclude<keyof T, symbol>;
+export type ObjectKeys<T extends Record<PropertyKey, unknown>> = `${Exclude<keyof T, symbol>}`;
 
 export function objectKeys<Type extends Record<PropertyKey, unknown>>(obj: Type): Array<ObjectKeys<Type>> {
   return Object.keys(obj) as Array<ObjectKeys<Type>>;


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

It works differently

I got this image error

<img width="796" alt="image" src="https://github.com/toss/slash/assets/69495129/a2af315c-583b-4b3d-b75e-24d7848a7eec">


The two TypeScript type declarations perform fundamentally similar roles, but they result in different types. Here are the differences:

```tsx
export declare type ObjectKeys<T extends Record<PropertyKey, unknown>> = `${Exclude<keyof T, symbol>}`;
```

This declaration converts all property keys of type T into string types. It forces the property keys into string types using Template Literal Types, which is a feature introduced in TypeScript 4.1. Consequently, this type becomes a union of string literals.

```tsx
export declare type ObjectKeys<T extends Record<PropertyKey, unknown>> = Exclude<keyof T, symbol>;
```
This declaration returns all property keys of type T but as keys themselves, not as strings. This type returns a union of all property keys of T excluding those of type symbol. Consequently, this type becomes a union of property keys.

Therefore, the primary difference is that the first declaration returns a union of string literals while the second one returns a union of property keys. Due to these differences, each declaration can be used for slightly different purposes.

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
