### PR TITLE
fix(@toss/date): unify rules

### DIFF
--- a/packages/common/date/src/date.ts
+++ b/packages/common/date/src/date.ts
@@ -8,10 +8,10 @@ export type DateFnsDateType = number | Date;
 
 export const kstFormat = (date: DateFnsDateType, format: string) => _format(date, format, { locale });
 
-export const roundUpHoursInDays = (hours: number) => {
+export function roundUpHoursInDays(hours: number) {
   const remainder = hours % 24;
   return remainder === 0 ? hours : hours + 24 - (hours % 24);
-};
+}
 
 export function parseYYYYMMDD(yyyyMMdd: string) {
   const date = new Date(yyyyMMdd);

--- a/packages/common/date/src/date.ts
+++ b/packages/common/date/src/date.ts
@@ -6,7 +6,9 @@ import locale from 'date-fns/locale/ko/index.js';
 // eslint-disable-next-line import/no-duplicates
 export type DateFnsDateType = number | Date;
 
-export const kstFormat = (date: DateFnsDateType, format: string) => _format(date, format, { locale });
+export function kstFormat(date: DateFnsDateType, format: string) {
+  _format(date, format, { locale });
+}
 
 export function roundUpHoursInDays(hours: number) {
   const remainder = hours % 24;


### PR DESCRIPTION
## Overview

The rules were unified

**question: Is there a reason why only certain parts are arrow functions?**

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
