### PR TITLE
feat(use-funnel): Make `router` able to be injected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ esm
 node_modules
 junit.xml
 *.tossdocs.md
+.idea

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -164,7 +164,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ["@toss/use-funnel", ["workspace:packages/react/use-funnel"]],\
       ["@toss/use-loading", ["workspace:packages/react/use-loading"]],\
       ["@toss/use-overlay", ["workspace:packages/react/use-overlay"]],\
-      ["@toss/use-query-param", ["virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#workspace:packages/react/use-query-param", "workspace:packages/react/use-query-param"]],\
+      ["@toss/use-query-param", ["workspace:packages/react/use-query-param"]],\
       ["@toss/utility-types", ["workspace:packages/common/utility-types"]],\
       ["@toss/utils", ["workspace:packages/common/utils"]],\
       ["@toss/validators", ["workspace:packages/common/validators"]],\
@@ -9580,7 +9580,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@toss/react", "virtual:b5b5dfb1662b30d0d5b62f084f8b8fddd0eee56dd8737572197395ab6309e644fa76525392b1d0250ce3c07c5eeeb90901439953af682fc76f8ab38f71b8b09d#workspace:packages/react/react"],\
             ["@toss/rollup-config", "virtual:bcd0c1141064bf940376b9b2c4f8a211deda5f9c27293f215379edb7c7917846a6a1d22044c7c1b3bb8002672fb9461cbd1f53c3889b2fe3b5bfbab9a70f1ac4#workspace:configs/rollup"],\
             ["@toss/storage", "workspace:packages/common/storage"],\
-            ["@toss/use-query-param", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#workspace:packages/react/use-query-param"],\
             ["@toss/utils", "workspace:packages/common/utils"],\
             ["@tossteam/jest", "virtual:bcd0c1141064bf940376b9b2c4f8a211deda5f9c27293f215379edb7c7917846a6a1d22044c7c1b3bb8002672fb9461cbd1f53c3889b2fe3b5bfbab9a70f1ac4#npm:17.187.2"],\
             ["@types/babel__core", "npm:7.1.19"],\
@@ -9597,7 +9596,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest", "virtual:01ae7c33d4655a48cbb29902912466a761e01d57e32af25620c31e36065eb1601cc4f6394afcb6b2f9c9f1b941b9fbeecba9aa1bca8ca304ae87cee07a6864e9#npm:29.1.2"],\
             ["jest-environment-jsdom", "npm:29.1.2"],\
             ["jest-localstorage-mock", "npm:2.4.22"],\
-            ["next", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#npm:12.1.1"],\
             ["next-router-mock", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#npm:0.6.10"],\
             ["react", "npm:18.2.0"],\
             ["react-dom", "virtual:62cb29918b2e63dff97923d985a18238631a18b918521fd9ac48de2be213715676e8b999d7ab4431ea536d1917af1465d5695ceae059c69bf4c14df5968dd6a1#npm:18.2.0"],\
@@ -9676,47 +9674,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@toss/use-query-param", [\
-        ["virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#workspace:packages/react/use-query-param", {\
-          "packageLocation": "./.yarn/__virtual__/@toss-use-query-param-virtual-dd7cbd2863/1/packages/react/use-query-param/",\
-          "packageDependencies": [\
-            ["@toss/use-query-param", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#workspace:packages/react/use-query-param"],\
-            ["@babel/core", "npm:7.19.3"],\
-            ["@babel/preset-env", "virtual:bcd0c1141064bf940376b9b2c4f8a211deda5f9c27293f215379edb7c7917846a6a1d22044c7c1b3bb8002672fb9461cbd1f53c3889b2fe3b5bfbab9a70f1ac4#npm:7.19.3"],\
-            ["@babel/preset-typescript", "virtual:bcd0c1141064bf940376b9b2c4f8a211deda5f9c27293f215379edb7c7917846a6a1d22044c7c1b3bb8002672fb9461cbd1f53c3889b2fe3b5bfbab9a70f1ac4#npm:7.18.6"],\
-            ["@babel/runtime", "npm:7.19.0"],\
-            ["@testing-library/jest-dom", "npm:5.16.5"],\
-            ["@testing-library/react", "virtual:62cb29918b2e63dff97923d985a18238631a18b918521fd9ac48de2be213715676e8b999d7ab4431ea536d1917af1465d5695ceae059c69bf4c14df5968dd6a1#npm:13.4.0"],\
-            ["@toss/rollup-config", "virtual:bcd0c1141064bf940376b9b2c4f8a211deda5f9c27293f215379edb7c7917846a6a1d22044c7c1b3bb8002672fb9461cbd1f53c3889b2fe3b5bfbab9a70f1ac4#workspace:configs/rollup"],\
-            ["@tossteam/jest", "virtual:bcd0c1141064bf940376b9b2c4f8a211deda5f9c27293f215379edb7c7917846a6a1d22044c7c1b3bb8002672fb9461cbd1f53c3889b2fe3b5bfbab9a70f1ac4#npm:17.187.2"],\
-            ["@types/babel__core", "npm:7.1.19"],\
-            ["@types/babel__preset-env", "npm:7.9.2"],\
-            ["@types/concurrently", "npm:6.4.0"],\
-            ["@types/jest", "npm:29.1.2"],\
-            ["@types/next", null],\
-            ["@types/react", "npm:18.0.21"],\
-            ["@types/react-dom", "npm:18.0.6"],\
-            ["@types/testing-library__jest-dom", "npm:5.14.5"],\
-            ["babel-jest", "virtual:785204e63ba96625a23f896ee431c9a36baff7a533742c7d2c1d3e8c51b41da4d9b22d61afa2e1bb44d0338b2a9e895a7c77e29d79f3a357a12dae28feb7f916#npm:29.1.2"],\
-            ["concurrently", "npm:6.5.1"],\
-            ["jest", "virtual:01ae7c33d4655a48cbb29902912466a761e01d57e32af25620c31e36065eb1601cc4f6394afcb6b2f9c9f1b941b9fbeecba9aa1bca8ca304ae87cee07a6864e9#npm:29.1.2"],\
-            ["jest-environment-jsdom", "npm:29.1.2"],\
-            ["jest-mock", "npm:27.5.1"],\
-            ["next", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#npm:12.1.1"],\
-            ["react", "npm:18.2.0"],\
-            ["react-dom", "virtual:62cb29918b2e63dff97923d985a18238631a18b918521fd9ac48de2be213715676e8b999d7ab4431ea536d1917af1465d5695ceae059c69bf4c14df5968dd6a1#npm:18.2.0"],\
-            ["rollup", "npm:2.79.1"],\
-            ["typescript", "patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"]\
-          ],\
-          "packagePeers": [\
-            "@types/next",\
-            "@types/react-dom",\
-            "@types/react",\
-            "next",\
-            "react-dom",\
-            "react"\
-          ],\
-          "linkType": "SOFT"\
-        }],\
         ["workspace:packages/react/use-query-param", {\
           "packageLocation": "./packages/react/use-query-param/",\
           "packageDependencies": [\
@@ -9741,7 +9698,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest", "virtual:01ae7c33d4655a48cbb29902912466a761e01d57e32af25620c31e36065eb1601cc4f6394afcb6b2f9c9f1b941b9fbeecba9aa1bca8ca304ae87cee07a6864e9#npm:29.1.2"],\
             ["jest-environment-jsdom", "npm:29.1.2"],\
             ["jest-mock", "npm:27.5.1"],\
-            ["next", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#npm:12.1.1"],\
+            ["next", "virtual:e9eb1d54f9fe7e0be78d794b90a35a0c1fc17a984d1e9fb9fcca059f0ebadc07d835815756c5a334a787c584bb03a1874e032d5d8dbf653e3df70c106b7592ec#npm:12.1.1"],\
             ["react", "npm:18.2.0"],\
             ["react-dom", "virtual:62cb29918b2e63dff97923d985a18238631a18b918521fd9ac48de2be213715676e8b999d7ab4431ea536d1917af1465d5695ceae059c69bf4c14df5968dd6a1#npm:18.2.0"],\
             ["rollup", "npm:2.79.1"],\
@@ -22989,10 +22946,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
-        ["virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#npm:12.1.1", {\
-          "packageLocation": "./.yarn/__virtual__/next-virtual-dd115039b9/0/cache/next-npm-12.1.1-53b3560094-2ace9622e6.zip/node_modules/next/",\
+        ["virtual:e9eb1d54f9fe7e0be78d794b90a35a0c1fc17a984d1e9fb9fcca059f0ebadc07d835815756c5a334a787c584bb03a1874e032d5d8dbf653e3df70c106b7592ec#npm:12.1.1", {\
+          "packageLocation": "./.yarn/__virtual__/next-virtual-6a9227d17f/0/cache/next-npm-12.1.1-53b3560094-2ace9622e6.zip/node_modules/next/",\
           "packageDependencies": [\
-            ["next", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#npm:12.1.1"],\
+            ["next", "virtual:e9eb1d54f9fe7e0be78d794b90a35a0c1fc17a984d1e9fb9fcca059f0ebadc07d835815756c5a334a787c584bb03a1874e032d5d8dbf653e3df70c106b7592ec#npm:12.1.1"],\
             ["@next/env", "npm:12.1.1"],\
             ["@next/swc-android-arm-eabi", "npm:12.1.1"],\
             ["@next/swc-android-arm64", "npm:12.1.1"],\
@@ -23050,7 +23007,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["next-router-mock", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#npm:0.6.10"],\
             ["@types/next", null],\
             ["@types/react", "npm:18.0.21"],\
-            ["next", "virtual:f6f04cf8049b336fe9077f5cdeccd69700881bd0ab0d34b6b3879d0cc74d55c0a524e5afdef6f46cf27faeec9176afe77367e6cf342fc58f394c0a51e51c18b1#npm:12.1.1"],\
+            ["next", null],\
             ["react", "npm:18.2.0"]\
           ],\
           "packagePeers": [\

--- a/packages/react/use-funnel/README.ko.md
+++ b/packages/react/use-funnel/README.ko.md
@@ -15,6 +15,41 @@
 
 ## 초기 설정
 
+useFunnel을 사용할 컴포넌트의 상위에서 RouterProvider를 사용해 router를 주입해주세요.
+```javascript
+import { RouterProvider } from '@toss/use-funnel';
+import { useRouter } from 'next/router';
+
+const FunnelPage = () => {
+  const router = useRouter();
+  return (
+    <RouterProvider router={router}>
+      <TestFunnels />
+    </RouterProvider>
+  );
+};
+
+const TestFunnels = () => {
+  const [퍼널, setStep] = useFunnel(['이름입력', '주민번호입력', '완료'] as const)
+
+  return (
+    <퍼널>
+      <퍼널.Step name="이름입력">
+        <이름입력스텝 /> // ?funnel-step=이름입력 스텝일 때 렌더
+      </퍼널.Step>
+      <퍼널.Step name="주민번호입력">
+        <주민번호입력스텝 /> // ?funnel-step=주민번호입력 스텝일 때 렌더
+      </퍼널.Step>
+      <퍼널.Step name="완료">
+        <퍼널완료스텝 /> // ?funnel-step=완료 스텝일 때 렌더
+      </퍼널.Step>
+    </퍼널>
+  )
+}
+
+
+```
+
 useFunnel을 사용하여 사용할 퍼널 스텝 리스트를 입력해주세요.
 
 ```javascript
@@ -39,7 +74,6 @@ useFunnel은 전달받은 스텝 리스트로 타이핑된 2개의 아이템이 
 정의된 각 퍼널 스텝은 `funnel-step`이라는 이름의 쿼리 파라미터와 스텝의 이름이 매칭될 경우 렌더링됩니다.
 
 ```javascript
-
 const [퍼널, setStep] = useFunnel(['이름입력', '주민번호입력', '완료'] as const)
 
 return (

--- a/packages/react/use-funnel/package.json
+++ b/packages/react/use-funnel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toss/use-funnel",
-  "version": "1.2.6",
+  "version": "2.0.0",
   "sideEffects": false,
   "exports": {
     ".": {
@@ -24,7 +24,6 @@
     "@toss/assert": "workspace:^1.1.10",
     "@toss/react": "workspace:^1.5.0",
     "@toss/storage": "workspace:^1.3.0",
-    "@toss/use-query-param": "workspace:^1.1.7",
     "@toss/utils": "workspace:^1.4.4",
     "fast-deep-equal": "^3.1.3"
   },
@@ -54,7 +53,6 @@
     "jest": "^29.0.1",
     "jest-environment-jsdom": "^29",
     "jest-localstorage-mock": "^2.4.21",
-    "next": "12.1.1",
     "next-router-mock": "^0.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -63,7 +61,6 @@
     "typescript": "4.8.3"
   },
   "peerDependencies": {
-    "next": "^11.1 || ^12 || ^13",
     "react": "^16.8 || ^17 || ^18",
     "react-dom": "^16.8 || ^17 || ^18",
     "react-query": "^3"

--- a/packages/react/use-funnel/src/RouterContext.tsx
+++ b/packages/react/use-funnel/src/RouterContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, ReactNode, useContext } from 'react';
+import { Router } from './router';
+import { assert } from '@toss/assert';
+
+const RouterContext = createContext<Router | null>(null);
+
+type RouterProviderProps = {
+  router: Router;
+  children: ReactNode;
+};
+
+export const RouterProvider = ({ router, children }: RouterProviderProps) => {
+  return <RouterContext.Provider value={router}>{children}</RouterContext.Provider>;
+};
+
+export const useRouter = () => {
+  const router = useContext(RouterContext);
+
+  assert(router, '라우터가 존재하지 않습니다. RouterProvider를 통해 주입해주세요.');
+
+  return router;
+};

--- a/packages/react/use-funnel/src/index.ts
+++ b/packages/react/use-funnel/src/index.ts
@@ -1,2 +1,3 @@
 /** @tossdocs-ignore */
 export * from './useFunnel';
+export { RouterProvider } from './RouterContext';

--- a/packages/react/use-funnel/src/router.ts
+++ b/packages/react/use-funnel/src/router.ts
@@ -1,0 +1,16 @@
+import type { ParsedUrlQuery } from 'querystring';
+import type { UrlObject } from 'url';
+
+type TransitionOptions = {
+  shallow?: boolean;
+};
+
+type Url = UrlObject | string;
+
+export type Router = {
+  push(url: Url, as?: Url, options?: TransitionOptions): Promise<boolean>;
+  replace(url: Url, as?: Url, options?: TransitionOptions): Promise<boolean>;
+  query: ParsedUrlQuery;
+  basePath: string;
+  pathname: string;
+};

--- a/packages/react/use-funnel/src/useFunnel.spec.tsx
+++ b/packages/react/use-funnel/src/useFunnel.spec.tsx
@@ -6,17 +6,18 @@ import { ReactNode, Suspense } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { useFunnel } from './useFunnel';
-
-jest.mock('next/router', () => require('next-router-mock'));
+import { RouterProvider } from './RouterContext';
 
 const 퍼널스텝리스트 = ['test1', 'test2'] as const;
 const queryClient = new QueryClient();
 
 function renderWithTestAppContext(node: ReactNode) {
   return render(
-    <QueryClientProvider client={queryClient}>
-      <Suspense fallback={null}>{node}</Suspense>
-    </QueryClientProvider>
+    <RouterProvider router={mockRouter}>
+      <QueryClientProvider client={queryClient}>
+        <Suspense fallback={null}>{node}</Suspense>
+      </QueryClientProvider>
+    </RouterProvider>
   );
 }
 

--- a/packages/react/use-funnel/src/useFunnel.tsx
+++ b/packages/react/use-funnel/src/useFunnel.tsx
@@ -2,14 +2,13 @@
 
 import { assert } from '@toss/assert';
 import { safeSessionStorage } from '@toss/storage';
-import { useQueryParam } from '@toss/use-query-param';
 import { QS } from '@toss/utils';
 import deepEqual from 'fast-deep-equal';
-import { useRouter } from 'next/router.js';
 import { SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'react-query';
 import { Funnel, FunnelProps, Step, StepProps } from './Funnel';
 import { NonEmptyArray } from './models';
+import { useRouter } from './RouterContext';
 
 interface SetStepOptions {
   stepChangeType?: 'push' | 'replace';
@@ -40,14 +39,14 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
   withState: <StateExcludeStep extends Record<string, unknown> & { step?: never }>(
     initialState: StateExcludeStep
   ) => [
-      FunnelComponent<Steps>,
-      StateExcludeStep,
-      (
-        next:
-          | Partial<StateExcludeStep & { step: Steps[number] }>
-          | ((next: Partial<StateExcludeStep & { step: Steps[number] }>) => StateExcludeStep & { step: Steps[number] })
-      ) => void
-    ];
+    FunnelComponent<Steps>,
+    StateExcludeStep,
+    (
+      next:
+        | Partial<StateExcludeStep & { step: Steps[number] }>
+        | ((next: Partial<StateExcludeStep & { step: Steps[number] }>) => StateExcludeStep & { step: Steps[number] })
+    ) => void
+  ];
 } => {
   const router = useRouter();
   const stepQueryKey = options?.stepQueryKey ?? DEFAULT_STEP_QUERY_KEY;
@@ -58,8 +57,7 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
     () =>
       Object.assign(
         function RouteFunnel(props: RouteFunnelProps<Steps>) {
-          // eslint-disable-next-line react-hooks/rules-of-hooks
-          const step = useQueryParam<Steps[number]>(stepQueryKey) ?? options?.initialStep;
+          const step = router.query[stepQueryKey]?.toString() ?? options?.initialStep;
 
           assert(
             step != null,
@@ -73,7 +71,7 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
         }
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [router.query]
   );
 
   const setStep = useCallback(
@@ -164,14 +162,14 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
     withState: <StateExcludeStep extends Record<string, unknown> & { step?: never }>(
       initialState: StateExcludeStep
     ) => [
-        FunnelComponent<Steps>,
-        StateExcludeStep,
-        (
-          next:
-            | Partial<StateExcludeStep & { step: Steps[number] }>
-            | ((next: Partial<StateExcludeStep & { step: Steps[number] }>) => StateExcludeStep & { step: Steps[number] })
-        ) => void
-      ];
+      FunnelComponent<Steps>,
+      StateExcludeStep,
+      (
+        next:
+          | Partial<StateExcludeStep & { step: Steps[number] }>
+          | ((next: Partial<StateExcludeStep & { step: Steps[number] }>) => StateExcludeStep & { step: Steps[number] })
+      ) => void
+    ];
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5399,7 +5399,6 @@ __metadata:
     "@toss/react": "workspace:^1.5.0"
     "@toss/rollup-config": "workspace:^0.1.4"
     "@toss/storage": "workspace:^1.3.0"
-    "@toss/use-query-param": "workspace:^1.1.7"
     "@toss/utils": "workspace:^1.4.4"
     "@tossteam/jest": ^17
     "@types/babel__core": ^7
@@ -5416,7 +5415,6 @@ __metadata:
     jest: ^29.0.1
     jest-environment-jsdom: ^29
     jest-localstorage-mock: ^2.4.21
-    next: 12.1.1
     next-router-mock: ^0.6.7
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -5424,7 +5422,6 @@ __metadata:
     rollup: ^2.77.0
     typescript: 4.8.3
   peerDependencies:
-    next: ^11.1 || ^12 || ^13
     react: ^16.8 || ^17 || ^18
     react-dom: ^16.8 || ^17 || ^18
     react-query: ^3
@@ -5498,7 +5495,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@toss/use-query-param@workspace:^1.1.7, @toss/use-query-param@workspace:packages/react/use-query-param":
+"@toss/use-query-param@workspace:packages/react/use-query-param":
   version: 0.0.0-use.local
   resolution: "@toss/use-query-param@workspace:packages/react/use-query-param"
   dependencies:


### PR DESCRIPTION
## Overview

next/router를 사용하지 않고 동일한 인터페이스의 객체를 context api를 통해 주입받습니다.
하위호환성이 지켜지지 않아 major 버전을 수정했습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
