### PR TITLE
fix(use-overlay): move incorrectly placed package from dependencies to devDependencies

### DIFF
--- a/packages/react/use-overlay/package.json
+++ b/packages/react/use-overlay/package.json
@@ -20,9 +20,6 @@
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "@types/react": "^18.0.21"
-  },
   "devDependencies": {
     "@babel/core": "^7",
     "@babel/preset-env": "^7.16.11",
@@ -41,6 +38,7 @@
     "@types/babel__preset-env": "^7",
     "@types/jest": "^28.1.8",
     "@types/node": "^14.14.41",
+    "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "@types/testing-library__jest-dom": "^5.14.2",
     "babel-jest": "^29",


### PR DESCRIPTION


## Overview

Moved incorrectly placed `"@types/react"` from dependencies to devDependencies

<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
