### PR TITLE
fix: modify ambiguous SemVer

### DIFF
--- a/packages/react/emotion-utils/package.json
+++ b/packages/react/emotion-utils/package.json
@@ -56,8 +56,8 @@
   },
   "peerDependencies": {
     "@emotion/react": "*",
-    "react": ">= 16 || ^18",
-    "react-dom": ">= 16 || ^18"
+    "react": "^16 | ^17| ^18",
+    "react-dom": "^16 | ^17 | ^18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react/emotion-utils/package.json
+++ b/packages/react/emotion-utils/package.json
@@ -56,8 +56,8 @@
   },
   "peerDependencies": {
     "@emotion/react": "*",
-    "react": "^16 | ^17| ^18",
-    "react-dom": "^16 | ^17 | ^18"
+    "react": "^16 || ^17 || ^18",
+    "react-dom": "^16 || ^17 || ^18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react/framer-motion/package.json
+++ b/packages/react/framer-motion/package.json
@@ -43,8 +43,8 @@
   },
   "peerDependencies": {
     "framer-motion": "*",
-    "react": ">=16.8.0 || ^17.0.0 || ^18",
-    "react-dom": ">=16.8.0 || ^17.0.0 || ^18"
+    "react": "^16.8.0 || ^17.0.0 || ^18",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react/react-query/package.json
+++ b/packages/react/react-query/package.json
@@ -43,7 +43,7 @@
     "typescript": "4.8.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0 || ^17.0.0 || ^18",
+    "react": "^16.8.0 || ^17.0.0 || ^18",
     "react-query": "*"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4961,8 +4961,8 @@ __metadata:
     typescript: 4.8.3
   peerDependencies:
     "@emotion/react": "*"
-    react: ">= 16 || ^18"
-    react-dom: ">= 16 || ^18"
+    react: ^16 || ^17 || ^18
+    react-dom: ^16 || ^17 || ^18
   languageName: unknown
   linkType: soft
 
@@ -5030,8 +5030,8 @@ __metadata:
     typescript: 4.8.3
   peerDependencies:
     framer-motion: "*"
-    react: ">=16.8.0 || ^17.0.0 || ^18"
-    react-dom: ">=16.8.0 || ^17.0.0 || ^18"
+    react: ^16.8.0 || ^17.0.0 || ^18
+    react-dom: ^16.8.0 || ^17.0.0 || ^18
   languageName: unknown
   linkType: soft
 
@@ -5163,7 +5163,7 @@ __metadata:
     tsd: ^0.24.1
     typescript: 4.8.3
   peerDependencies:
-    react: ">=16.8.0 || ^17.0.0 || ^18"
+    react: ^16.8.0 || ^17.0.0 || ^18
     react-query: "*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Overview



<!--
    A clear and concise description of what this pr is about.
 -->
 ### Changes
- react/framer-motion
- react/emotion-utils
- react/react-query


> It means the same thing.

`"react": ">=16.8.0 || ^17.0.0 || ^18"`   === `"react": ">=16.8.0"`  
- [SemVer check](https://semver.npmjs.com/#syntax-examples)    

### What version were you intending to use?
-  `"react": ">=16.8.0"` ?
-  `"react": "^16.8.0 || ^17.0.0 || ^18"` ?

Considering the presence of the `||` symbols after `>=16.8.0`, it seems that the intended version was `"^16.8.0 || ^17.0.0 || ^18"`. I have modified the semver to `"react": "^16.8.0 || ^17.0.0 || ^18"`.
If the intention was to specify `>=16.8.0`, I will modify it to `"react": ">=16.8.0"`.


<br>

>When using `>=` in conjunction with `||`, it is typically used as follows: [link](https://github.com/nodejs/node-gyp/blob/main/package.json)
```json
"engines": {
    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
  },
```


---

### 📌 react-query

#### [v1 peerDependencies](https://github.com/TanStack/query/blob/1.x/package.json)

```json
"peerDependencies": {
    "react": "^16.8.0"
  },
```

#### [v2 peerDependencies](https://github.com/TanStack/query/blob/2.x/package.json)

```json
"peerDependencies": {
    "react": "^16.8.0 || ^17.0.0"
  },
```

#### [v3 peerDependencies](https://github.com/TanStack/query/blob/v3/package.json)
```json
 "peerDependencies": {
    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
  },
```


### 📌 @emotion/react

#### v11.9.3 
```json
"peerDependencies": {
    "@babel/core": "^7.0.0",
    "react": ">=16.8.0"
}
    
```    

### 📌 framer-motion
The only unnecessary part was included in the peerDependencies.
[At first, I set up peerDependencies correctly.](https://github.com/framer/motion/pull/847)
"However, unnecessary additions were made starting from [v3.7](https://github.com/framer/motion/blob/main/CHANGELOG.md#370-2021-02-23) 
Starting from [v7](https://github.com/framer/motion/releases/tag/v7.0.0), [the minimum React version requirement was updated to v18](https://www.framer.com/motion/guide-upgrade/#70), and it was indicated correctly."

#### ❗️v6
```json
"peerDependencies": {
    "react": ">=16.8 || ^17.0.0 || ^18.0.0",
    "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
}
```

#### ✅ v7
```json
"peerDependencies": {
    "react": "^18.0.0",
    "react-dom": "^18.0.0"
}
```


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
