### PR TITLE
refac: userEvent Setup Code

### DIFF
--- a/packages/react/error-boundary/src/ErrorBoundaryGroup.spec.tsx
+++ b/packages/react/error-boundary/src/ErrorBoundaryGroup.spec.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundaryGroup, useErrorBoundaryGroup } from './ErrorBoundaryGroup'
 
 describe('ErrorBoundaryGroup', () => {
   it('can reset errors in the group', async () => {
+    const user = userEvent.setup();
     const state = { hasError: true };
 
     function ErrorComponent() {
@@ -44,8 +45,6 @@ describe('ErrorBoundaryGroup', () => {
     );
 
     expect(screen.getByText(`An error occurred: This is an error`)).toBeInTheDocument();
-
-    const user = await userEvent.setup();
 
     await user.click(screen.getByRole('button', { name: `Reset` }));
 

--- a/packages/react/react/src/hooks/useCombinedRefs.spec.tsx
+++ b/packages/react/react/src/hooks/useCombinedRefs.spec.tsx
@@ -5,6 +5,7 @@ import { useCombinedRefs } from './useCombinedRefs';
 
 describe('useCombinedRefs', () => {
   it('여러 개의 ref를 하나로 합칠 수 있다.', async () => {
+    const user = userEvent.setup();
     const refs: Array<HTMLDivElement | null> = [];
     const callbackRef = jest.fn();
 
@@ -33,7 +34,7 @@ describe('useCombinedRefs', () => {
 
     render(<TestComponent />);
 
-    await userEvent.click(await screen.findByRole('button', { name: 'ref 저장하기' }));
+    await user.click(await screen.findByRole('button', { name: 'ref 저장하기' }));
 
     expect(refs.length).toEqual(3);
 

--- a/packages/react/react/src/hooks/useOutsideClickEffect.spec.tsx
+++ b/packages/react/react/src/hooks/useOutsideClickEffect.spec.tsx
@@ -42,13 +42,14 @@ describe('useOutsideClickEffect', () => {
   }
 
   it('컨테이너 바깥에 위치한 DOM에서 이벤트가 발생하면 콜백이 호출된다.', async () => {
+    const user = userEvent.setup();
     const onEffect = jest.fn();
     prepare({ onEffect });
 
-    userEvent.click(screen.getByTestId('container-0'));
+    await user.click(screen.getByTestId('container-0'));
     expect(onEffect).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByTestId('outside'));
+    await user.click(screen.getByTestId('outside'));
 
     await waitFor(() => {
       expect(onEffect).toHaveBeenCalled();
@@ -61,31 +62,34 @@ describe('useOutsideClickEffect', () => {
     });
   });
 
-  it('컨테이너 안쪽에 위치한 DOM에서 이벤트가 발생하면 콜백이 호출되지 않는다.', () => {
+  it('컨테이너 안쪽에 위치한 DOM에서 이벤트가 발생하면 콜백이 호출되지 않는다.', async () => {
+    const user = userEvent.setup();
     const onEffect = jest.fn();
     prepare({ onEffect });
 
-    userEvent.click(screen.getByTestId('inside-0'));
+    await user.click(screen.getByTestId('inside-0'));
     expect(onEffect).not.toHaveBeenCalled();
   });
 
   it('컨테이너를 여러개 지정할 수 있다.', async () => {
+    const user = userEvent.setup();
     const onEffect = jest.fn();
     prepare({ containerCount: 3, onEffect });
 
-    userEvent.click(screen.getByTestId('container-0'));
+    await user.click(screen.getByTestId('container-0'));
     expect(onEffect).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByTestId('container-1'));
+    await user.click(screen.getByTestId('container-1'));
     expect(onEffect).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByTestId('container-2'));
+    await user.click(screen.getByTestId('container-2'));
     expect(onEffect).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByTestId('inside-2'));
+    await user.click(screen.getByTestId('inside-2'));
     expect(onEffect).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByTestId('outside'));
+    await user.click(screen.getByTestId('outside'));
+
     await waitFor(() => {
       expect(onEffect).toHaveBeenCalled();
     });

--- a/packages/react/use-funnel/src/useFunnel.spec.tsx
+++ b/packages/react/use-funnel/src/useFunnel.spec.tsx
@@ -42,6 +42,8 @@ describe('useFunnel이 정상적으로 동작하는 테스트', () => {
   });
 
   it('test1에서 setStep을 클릭하여 test2 스텝으로 넘어간다.', async () => {
+    const user = userEvent.setup();
+
     function TestComponent() {
       const [테스트퍼널, setStep] = useFunnel(퍼널스텝리스트);
 
@@ -62,13 +64,14 @@ describe('useFunnel이 정상적으로 동작하는 테스트', () => {
     renderWithTestAppContext(<TestComponent />);
 
     const button = await screen.findByRole('button', { name: 'next' });
-    await userEvent.click(button);
+    await user.click(button);
 
     expect(mockRouter.query['funnel-step']).toBe('test2');
     expect(await screen.findByText('Test2')).toBeInTheDocument();
   });
 
   it('test1에서 setStep을 클릭하여 test2 스텝으로 넘어갈 때, test2에 걸린 onEnter와 useFunnel에 걸어 놓은 onStepChange가 호출된다.', async () => {
+    const user = userEvent.setup();
     const handleStepChange = jest.fn((name: typeof 퍼널스텝리스트[number]) => {
       return name;
     });
@@ -96,13 +99,15 @@ describe('useFunnel이 정상적으로 동작하는 테스트', () => {
     renderWithTestAppContext(<TestComponent />);
 
     const button = await screen.findByRole('button', { name: 'next' });
-    await userEvent.click(button);
+    await user.click(button);
 
     await waitFor(() => expect(handleStepChange).toBeCalledWith('test2'));
     await waitFor(() => expect(handleTest2Enter).toBeCalled());
   });
 
   it("setStep('test2', { preserveQuery: true }) 시 funnel-step는 test2로, 그 외의 쿼리들은 유지된다.", async () => {
+    const user = userEvent.setup();
+
     function TestComponent() {
       const [테스트퍼널, setStep] = useFunnel(퍼널스텝리스트);
 
@@ -123,7 +128,7 @@ describe('useFunnel이 정상적으로 동작하는 테스트', () => {
     renderWithTestAppContext(<TestComponent />);
 
     const button = await screen.findByRole('button', { name: 'next' });
-    await userEvent.click(button);
+    await user.click(button);
 
     expect(mockRouter.query['funnel-step']).toBe('test2');
     expect(mockRouter.query['test']).toBe('test');
@@ -160,7 +165,9 @@ describe('useFunnel이 정상적으로 동작하는 테스트', () => {
   });
 
   it('options에 stepQueryKey가 kkk이면, 현재 스텝을 나타내는 query key는 kkk이고 setStep 시 kkk가 변경된다.', async () => {
+    const user = userEvent.setup();
     const CUSTOM_QUERY_KEY = 'kkk';
+
     function TestComponent() {
       const [테스트퍼널, setStep] = useFunnel(퍼널스텝리스트, { initialStep: 'test1', stepQueryKey: CUSTOM_QUERY_KEY });
 
@@ -181,7 +188,7 @@ describe('useFunnel이 정상적으로 동작하는 테스트', () => {
     renderWithTestAppContext(<TestComponent />);
 
     const button = await screen.findByRole('button', { name: 'next' });
-    await userEvent.click(button);
+    await user.click(button);
 
     expect(mockRouter.query[CUSTOM_QUERY_KEY]).toBe('test2');
   });
@@ -189,6 +196,8 @@ describe('useFunnel이 정상적으로 동작하는 테스트', () => {
 
 describe('useFunnel.withState', () => {
   it('퍼널 스텝과 퍼널 상태를 동시에 갱신할 수 있다: 퍼널 스텝을 변경할 때 퍼널 상태 갱신이 완료될 때까지 지연할 수 있다', async () => {
+    const user = userEvent.setup();
+
     mockRouter.setCurrentUrl(`?funnel-step=시작`);
 
     function FunnelPage() {
@@ -223,7 +232,7 @@ describe('useFunnel.withState', () => {
 
     renderWithTestAppContext(<FunnelPage />);
 
-    await userEvent.click(await screen.findByRole('button', { name: '확인' }));
+    await user.click(await screen.findByRole('button', { name: '확인' }));
 
     expect(await screen.findByText('1')).toBeInTheDocument();
   });

--- a/packages/react/use-overlay/src/tests/exit.spec.tsx
+++ b/packages/react/use-overlay/src/tests/exit.spec.tsx
@@ -17,19 +17,21 @@ function TestComponent() {
 
 describe('useOverlay', () => {
   it('should unmount overlay when exit function is called', async () => {
+    const user = userEvent.setup();
+
     renderWithContext(<TestComponent />);
 
     const openButton = screen.getByText('open');
     const closeButton = screen.getByText('close');
     const exitButton = screen.getByText('exit');
 
-    await userEvent.click(openButton);
+    await user.click(openButton);
     expect(screen.getByText('toss')).toBeInTheDocument();
 
-    await userEvent.click(closeButton);
+    await user.click(closeButton);
     expect(screen.getByText('toss')).toBeInTheDocument();
 
-    await userEvent.click(exitButton);
+    await user.click(exitButton);
     expect(screen.queryByText('toss')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Overview

Starting with userEvent `v14`, it is recommended to call `userEvent.setup()` before rendering the component.

I have refactored the code using userEvent as per the guide.

https://testing-library.com/docs/user-event/intro#writing-tests-with-userevent

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
