### PR TITLE
refac(@toss/utils): Improved object utils function types 

### DIFF
--- a/packages/common/utils/src/object/object-entries.ts
+++ b/packages/common/utils/src/object/object-entries.ts
@@ -1,8 +1,4 @@
 /** @tossdocs-ignore */
-import { ObjectKeys } from './object-keys.js';
-
-export function objectEntries<Type extends Record<PropertyKey, unknown>>(
-  obj: Type
-): Array<[ObjectKeys<Type>, Type[ObjectKeys<Type>]]> {
-  return Object.entries(obj) as Array<[ObjectKeys<Type>, Type[ObjectKeys<Type>]]>;
+export function objectEntries<T extends Record<PropertyKey, T[keyof T]>>(obj: T): Array<[keyof T, T[keyof T]]> {
+  return Object.entries(obj);
 }

--- a/packages/common/utils/src/object/object-keys.ts
+++ b/packages/common/utils/src/object/object-keys.ts
@@ -1,6 +1,4 @@
 /** @tossdocs-ignore */
-export type ObjectKeys<T extends Record<PropertyKey, unknown>> = `${Exclude<keyof T, symbol>}`;
-
-export function objectKeys<Type extends Record<PropertyKey, unknown>>(obj: Type): Array<ObjectKeys<Type>> {
-  return Object.keys(obj) as Array<ObjectKeys<Type>>;
+export function objectKeys<T extends Record<PropertyKey, T[keyof T]>>(obj: T): Array<keyof T> {
+  return Object.keys(obj);
 }

--- a/packages/common/utils/src/object/object-values.ts
+++ b/packages/common/utils/src/object/object-values.ts
@@ -1,6 +1,5 @@
 /** @tossdocs-ignore */
-import { ObjectKeys } from './object-keys';
 
-export function objectValues<Type extends Record<PropertyKey, unknown>>(obj: Type): Array<Type[ObjectKeys<Type>]> {
-  return Object.values(obj) as Array<Type[ObjectKeys<Type>]>;
+export function objectValues<T extends Record<PropertyKey, T[keyof T]>>(obj: T): Array<T[keyof T]> {
+  return Object.values(obj);
 }

--- a/packages/common/utils/src/object/omit.ts
+++ b/packages/common/utils/src/object/omit.ts
@@ -1,12 +1,12 @@
 /** @tossdocs-ignore */
-import { ObjectKeys, objectKeys } from './object-keys';
+import { objectKeys } from './object-keys';
 import { ElementType } from './types';
 
-export function omit<ObjectType extends Record<PropertyKey, any>, KeyTypes extends Array<ObjectKeys<ObjectType>>>(
-  obj: ObjectType,
-  keys: KeyTypes
-) {
+export function omit<T extends Record<PropertyKey, T[keyof T]>, K extends Array<keyof T>>(
+  obj: T,
+  keys: K
+): Omit<T, ElementType<K>> {
   return objectKeys(obj)
-    .filter((k): k is Exclude<ObjectKeys<ObjectType>, ElementType<KeyTypes>> => !keys.includes(k))
-    .reduce((acc, key) => ((acc[key] = obj[key]), acc), {} as Omit<ObjectType, ElementType<KeyTypes>>);
+    .filter((k): k is Exclude<keyof T, ElementType<K>> => !keys.includes(k))
+    .reduce((acc, key) => ((acc[key] = obj[key]), acc), {} as Omit<T, ElementType<K>>);
 }


### PR DESCRIPTION
## Overview
I think `"keyof T"` for the "key" of an object and `"T[keyof T]"` for the type of the "value" is sufficient.

```ts
const obj = {
  a: 1,
  b: 2,
  c: 3,
} as const;

type keys = keyof typeof obj; // "a" | "b" | "c"
type values = (typeof obj)[keyof typeof obj]; // 1 | 2 | 3
```

So in the `Record<PropertyKey, unknown>` part, it would be clearer and better to write `T[keyof T]` for `unknown`.

```ts
// as-is
<T extends Record<PropertyKey, unknown>>

// to-be
<T extends Record<PropertyKey, T[keyof T]>>
```

The existing `ObjectKeys` seems to make the type complex.
we don't need to make `type assertions` after modifying a type.

```ts
// as-is
export type ObjectKeys<T extends Record<PropertyKey, unknown>> = `${Exclude<keyof T, symbol>}`;

export function objectKeys<Type extends Record<PropertyKey, unknown>>(obj: Type): Array<ObjectKeys<Type>> {
  return Object.keys(obj) as Array<ObjectKeys<Type>>;
}

// to-be 1
export function objectKeys<T extends Record<PropertyKey, T[keyof T]>>(obj: T): Array<keyof T> {
  return Object.keys(obj); // (*)
}
```

<br />

Of course, it seems possible to define and utilize the types `ObjectValues` and `ObjectKeys` anew.

```ts
// to-be 2
type ObjectValues<T extends Record<PropertyKey, T[keyof T]>> = T[keyof T];
type ObjectKeys<T extends Record<PropertyKey, T[keyof T]>> = keyof T;

export const objectKeys = <T extends Record<PropertyKey, ObjectValues<T>>>(
  obj: T
): Array<ObjectKeys<T>> => {
  return Object.keys(obj);
};
```
The type inference result is the same after the change!! 👍

## to-be
### objectKeys
![keys](https://github.com/toss/slash/assets/64779472/2ac5bef4-3bc4-4f43-ac5f-8c1266f45bf0)

<br />

### objectValues
![values](https://github.com/toss/slash/assets/64779472/f141c04b-7819-4834-9859-e58a8e6bc60a)

<br />

### objectEntries
![스크린샷 2023-10-12 오후 3 13 35](https://github.com/toss/slash/assets/64779472/59be9e6a-e4d5-4fb5-8451-5d9d3b4cb8ad)

<br />

### omit
![omit](https://github.com/toss/slash/assets/64779472/2afed73e-8a00-4799-8a9e-430b41a9ec74)
<br />

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
