### PR TITLE
fix(@toss/react): Fix the useOutsideClickEffect callback function to be called only once

### DIFF
--- a/packages/react/react/src/hooks/useOutsideClickEffect.ts
+++ b/packages/react/react/src/hooks/useOutsideClickEffect.ts
@@ -1,4 +1,4 @@
-import { isNotNil } from '@toss/utils';
+import { isMobileWeb, isNotNil } from '@toss/utils';
 import { useCallback, useEffect, useRef } from 'react';
 
 type OneOrMore<T> = T | T[];
@@ -31,12 +31,18 @@ export function useOutsideClickEffect(container: OneOrMore<HTMLElement | null>, 
   );
 
   useEffect(() => {
-    document.addEventListener('click', handleDocumentClick);
-    document.addEventListener('touchstart', handleDocumentClick);
+    if (isMobileWeb()) {
+      document.addEventListener('touchstart', handleDocumentClick);
+    } else {
+      document.addEventListener('click', handleDocumentClick);
+    }
 
     return () => {
-      document.removeEventListener('click', handleDocumentClick);
-      document.removeEventListener('touchstart', handleDocumentClick);
+      if (isMobileWeb()) {
+        document.removeEventListener('touchstart', handleDocumentClick);
+      } else {
+        document.removeEventListener('click', handleDocumentClick);
+      }
     };
   });
 }


### PR DESCRIPTION
## Overview

FIX #354 

Because of the [limitations on the touch event test in Testing library](https://github.com/testing-library/user-event/issues/880), no way to test was found. 
Let me know if there's any other way

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
