### PR TITLE
test(@toss/utils): Improve groupBy Function Tests (Translation and Case Sensitivity Enhancement)

### DIFF
--- a/packages/common/utils/src/groupBy.spec.ts
+++ b/packages/common/utils/src/groupBy.spec.ts
@@ -1,6 +1,6 @@
 import { groupBy } from './groupBy';
 
-describe('groupBy 함수는', () => {
+describe('The groupBy function', () => {
   const input = [
     { groupName: '부엉이', value: 1 },
     { groupName: '다람쥐', value: 2 },
@@ -10,7 +10,7 @@ describe('groupBy 함수는', () => {
     { groupName: '부엉이', value: 6 },
   ];
 
-  it('createKey의 return value를 이용해서 item을 묶는다', () => {
+  it('groups items using the return value of createKey', () => {
     expect(groupBy(input, ({ groupName }) => groupName)).toEqual({
       부엉이: [
         { groupName: '부엉이', value: 1 },
@@ -25,7 +25,7 @@ describe('groupBy 함수는', () => {
     });
   });
 
-  it('빈 Array를 넣었을 땐 빈 object를 return한다.', () => {
+  it('returns an empty object when given an empty array', () => {
     expect(groupBy([], ({ someKey }) => someKey)).toEqual({});
   });
 });

--- a/packages/common/utils/src/groupBy.spec.ts
+++ b/packages/common/utils/src/groupBy.spec.ts
@@ -25,6 +25,24 @@ describe('The groupBy function', () => {
     });
   });
 
+  it('groups items distinguishing between uppercase and lowercase', () => {
+    const caseSensitiveInput = [
+      { name: 'apple', value: 1 },
+      { name: 'apple', value: 2 },
+      { name: 'Apple', value: 3 },
+      { name: 'banana', value: 4 },
+    ];
+
+    expect(groupBy(caseSensitiveInput, item => item.name)).toEqual({
+      apple: [
+        { name: 'apple', value: 1 },
+        { name: 'apple', value: 2 },
+      ],
+      Apple: [{ name: 'Apple', value: 3 }],
+      banana: [{ name: 'banana', value: 4 }],
+    });
+  });
+
   it('returns an empty object when given an empty array', () => {
     expect(groupBy([], ({ someKey }) => someKey)).toEqual({});
   });

--- a/packages/common/utils/src/groupBy.spec.ts
+++ b/packages/common/utils/src/groupBy.spec.ts
@@ -10,7 +10,7 @@ describe('The groupBy function', () => {
     { groupName: '부엉이', value: 6 },
   ];
 
-  it('groups items using the return value of createKey', () => {
+  it('should group items using the return value of createKey', () => {
     expect(groupBy(input, ({ groupName }) => groupName)).toEqual({
       부엉이: [
         { groupName: '부엉이', value: 1 },
@@ -25,7 +25,7 @@ describe('The groupBy function', () => {
     });
   });
 
-  it('groups items distinguishing between uppercase and lowercase', () => {
+  it('should group items distinguishing between uppercase and lowercase', () => {
     const caseSensitiveInput = [
       { name: 'apple', value: 1 },
       { name: 'apple', value: 2 },
@@ -43,7 +43,7 @@ describe('The groupBy function', () => {
     });
   });
 
-  it('returns an empty object when given an empty array', () => {
+  it('should return an empty object when given an empty array', () => {
     expect(groupBy([], ({ someKey }) => someKey)).toEqual({});
   });
 });


### PR DESCRIPTION
## Overview

1. Translate groupBy test descriptions from Korean to English for clarity and global team accessibility
2. Enhance groupBy tests with case sensitivity check
I added a new test case because the existing code's test cases were only in Korean, and there was no example case to check if the return value of createKey distinguishes between uppercase and lowercase when it's in English


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
4. I have written documents and tests, if needed.
