### PR TITLE
docs(@toss/react): fix syntax error in example code

### DIFF
--- a/packages/react/react/src/utils/buildContext.en.md
+++ b/packages/react/react/src/utils/buildContext.en.md
@@ -13,10 +13,10 @@ This is a helper function that reduces repetitive code when defining React Conte
 ## Examples
 
 ```tsx
-const [Provider, useContext] = buildContext('TestContext', null);
+const [Provider, useContext] = buildContext<{ title: string }>('TestContext', null);
 
 function Inner() {
-  const context = useContext < { title: string } > 'Inner';
+  const context = useContext();
 
   return <h1>{context.title}</h1>;
 }

--- a/packages/react/react/src/utils/buildContext.ko.md
+++ b/packages/react/react/src/utils/buildContext.ko.md
@@ -13,10 +13,10 @@ React Context를 정의할 때 반복되는 코드를 줄여주는 헬퍼 함수
 ## Examples
 
 ```tsx
-const [Provider, useContext] = buildContext('TestContext', null);
+const [Provider, useContext] = buildContext<{ title: string }>('TestContext', null);
 
 function Inner() {
-  const context = useContext < { title: string } > 'Inner';
+  const context = useContext();
 
   return <h1>{context.title}</h1>;
 }


### PR DESCRIPTION
## Overview

I identified a syntax error in the example code. Upon reviewing the test code, it appears that the example needs to be modified as follows:

```tsx
const [Provider, useContext] = buildContext<{ title: string }>('TestContext', null);

function Inner() {
  const context = useContext();

  return <h1>{context.title}</h1>;
}

function Page() {
  return (
    <Provider title="타이틀">
      <Inner />
    </Provider>
  );
}
```


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
