### PR TITLE
test(@toss/utils): Enhance Test Coverage and Clarity for Get and Set Functions

### DIFF
--- a/packages/common/utils/src/get-set.spec.ts
+++ b/packages/common/utils/src/get-set.spec.ts
@@ -4,20 +4,16 @@ describe('get function', () => {
   it('correctly retrieves a value for a single-level property', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a')).toStrictEqual({ b: { c: 'd' } });
   });
-
   it('correctly retrieves a value for a multi-level property', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a.b')).toStrictEqual({ c: 'd' });
     expect(get({ a: { b: { c: 'd' } } }, 'a.b.c')).toStrictEqual('d');
   });
-
   it('returns a default value when the specified path does not exist', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a.c', 'default')).toStrictEqual('default');
   });
-
   it('ignores consecutive dots in path and retrieves the correct value', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a..b')).toStrictEqual({ c: 'd' });
   });
-
   it('works correctly with empty objects', () => {
     expect(get({}, 'a')).toBeUndefined();
   });
@@ -27,21 +23,17 @@ describe('set function', () => {
   it('correctly sets a value for a single-level property', () => {
     expect(set({ a: { b: { c: 'd' } } }, 'a', 'e')).toStrictEqual({ a: 'e' });
   });
-
   it('correctly sets a value for a multi-level property', () => {
     expect(set({ a: { b: { c: 'd' } } }, 'a.b.c', 'e')).toStrictEqual({ a: { b: { c: 'e' } } });
   });
-
   it('correctly adds a new property at a multi-level path', () => {
     expect(set({ a: { b: { c: 'c' } } }, 'a.b.e', 'e')).toStrictEqual({ a: { b: { c: 'c', e: 'e' } } });
   });
-
   it('handles incorrect path formats gracefully', () => {
     // Assuming the function does not modify the object in case of an incorrect path
     const obj = { a: { b: { c: 'd' } } };
     expect(set(obj, 'a..b', 'e')).toStrictEqual(obj);
   });
-
   it('works correctly with empty objects', () => {
     expect(set({}, 'a', 'b')).toStrictEqual({ a: 'b' });
   });

--- a/packages/common/utils/src/get-set.spec.ts
+++ b/packages/common/utils/src/get-set.spec.ts
@@ -1,39 +1,39 @@
 import { get, set } from './get-set';
 
 describe('get function', () => {
-  it('correctly retrieves a value for a single-level property', () => {
+  it('should correctly retrieve a value for a single-level property', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a')).toStrictEqual({ b: { c: 'd' } });
   });
-  it('correctly retrieves a value for a multi-level property', () => {
+  it('should correctly retrieve a value for a multi-level property', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a.b')).toStrictEqual({ c: 'd' });
     expect(get({ a: { b: { c: 'd' } } }, 'a.b.c')).toStrictEqual('d');
   });
-  it('returns a default value when the specified path does not exist', () => {
+  it('should return a default value when the specified path does not exist', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a.c', 'default')).toStrictEqual('default');
   });
-  it('ignores consecutive dots in path and retrieves the correct value', () => {
+  it('should ignore consecutive dots in path and retrieve the correct value', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a..b')).toStrictEqual({ c: 'd' });
   });
-  it('works correctly with empty objects', () => {
+  it('should work correctly with empty objects', () => {
     expect(get({}, 'a')).toBeUndefined();
   });
 });
 
 describe('set function', () => {
-  it('correctly sets a value for a single-level property', () => {
+  it('should correctly set a value for a single-level property', () => {
     expect(set({ a: { b: { c: 'd' } } }, 'a', 'e')).toStrictEqual({ a: 'e' });
   });
-  it('correctly sets a value for a multi-level property', () => {
+  it('should correctly set a value for a multi-level property', () => {
     expect(set({ a: { b: { c: 'd' } } }, 'a.b.c', 'e')).toStrictEqual({ a: { b: { c: 'e' } } });
   });
-  it('correctly adds a new property at a multi-level path', () => {
+  it('should correctly add a new property at a multi-level path', () => {
     expect(set({ a: { b: { c: 'c' } } }, 'a.b.e', 'e')).toStrictEqual({ a: { b: { c: 'c', e: 'e' } } });
   });
-  it('assuming the function does not modify the object in case of an incorrect path', () => {
+  it('should handle incorrect path formats gracefully', () => {
     const obj = { a: { b: { c: 'd' } } };
     expect(set(obj, 'a..b', 'e')).toStrictEqual(obj);
   });
-  it('works correctly with empty objects', () => {
+  it('should work correctly with empty objects', () => {
     expect(set({}, 'a', 'b')).toStrictEqual({ a: 'b' });
   });
 });

--- a/packages/common/utils/src/get-set.spec.ts
+++ b/packages/common/utils/src/get-set.spec.ts
@@ -29,8 +29,7 @@ describe('set function', () => {
   it('correctly adds a new property at a multi-level path', () => {
     expect(set({ a: { b: { c: 'c' } } }, 'a.b.e', 'e')).toStrictEqual({ a: { b: { c: 'c', e: 'e' } } });
   });
-  it('handles incorrect path formats gracefully', () => {
-    // Assuming the function does not modify the object in case of an incorrect path
+  it('assuming the function does not modify the object in case of an incorrect path', () => {
     const obj = { a: { b: { c: 'd' } } };
     expect(set(obj, 'a..b', 'e')).toStrictEqual(obj);
   });

--- a/packages/common/utils/src/get-set.spec.ts
+++ b/packages/common/utils/src/get-set.spec.ts
@@ -1,26 +1,30 @@
 import { get, set } from './get-set';
 
-describe('get은', () => {
-  it('한 단계 path를 잘 get한다', () => {
+describe('get function', () => {
+  it('correctly retrieves a value for a single-level property', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a')).toStrictEqual({ b: { c: 'd' } });
   });
-  it('여러 단계 path를 잘 get한다', () => {
+
+  it('correctly retrieves a value for a multi-level property', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a.b')).toStrictEqual({ c: 'd' });
     expect(get({ a: { b: { c: 'd' } } }, 'a.b.c')).toStrictEqual('d');
   });
-  it('경로에 해당하는 값이 없을 때 기본값을 반환한다', () => {
-    expect(get({ a: { b: { c: 'd' } } }, 'a.c',"f")).toStrictEqual("f");
+
+  it('returns a default value when the specified path does not exist', () => {
+    expect(get({ a: { b: { c: 'd' } } }, 'a.c', 'default')).toStrictEqual('default');
   });
 });
 
-describe('set은', () => {
-  it('한 단계 path를 잘 set한다', () => {
+describe('set function', () => {
+  it('correctly sets a value for a single-level property', () => {
     expect(set({ a: { b: { c: 'd' } } }, 'a', 'e')).toStrictEqual({ a: 'e' });
   });
-  it('여러 단계 path를 잘 set한다', () => {
+
+  it('correctly sets a value for a multi-level property', () => {
     expect(set({ a: { b: { c: 'd' } } }, 'a.b.c', 'e')).toStrictEqual({ a: { b: { c: 'e' } } });
   });
-  it('여러 단계 path를 잘 set한다', () => {
+
+  it('correctly adds a new property at a multi-level path', () => {
     expect(set({ a: { b: { c: 'c' } } }, 'a.b.e', 'e')).toStrictEqual({ a: { b: { c: 'c', e: 'e' } } });
   });
 });

--- a/packages/common/utils/src/get-set.spec.ts
+++ b/packages/common/utils/src/get-set.spec.ts
@@ -13,6 +13,14 @@ describe('get function', () => {
   it('returns a default value when the specified path does not exist', () => {
     expect(get({ a: { b: { c: 'd' } } }, 'a.c', 'default')).toStrictEqual('default');
   });
+
+  it('ignores consecutive dots in path and retrieves the correct value', () => {
+    expect(get({ a: { b: { c: 'd' } } }, 'a..b')).toStrictEqual({ c: 'd' });
+  });
+
+  it('works correctly with empty objects', () => {
+    expect(get({}, 'a')).toBeUndefined();
+  });
 });
 
 describe('set function', () => {
@@ -26,5 +34,15 @@ describe('set function', () => {
 
   it('correctly adds a new property at a multi-level path', () => {
     expect(set({ a: { b: { c: 'c' } } }, 'a.b.e', 'e')).toStrictEqual({ a: { b: { c: 'c', e: 'e' } } });
+  });
+
+  it('handles incorrect path formats gracefully', () => {
+    // Assuming the function does not modify the object in case of an incorrect path
+    const obj = { a: { b: { c: 'd' } } };
+    expect(set(obj, 'a..b', 'e')).toStrictEqual(obj);
+  });
+
+  it('works correctly with empty objects', () => {
+    expect(set({}, 'a', 'b')).toStrictEqual({ a: 'b' });
   });
 });


### PR DESCRIPTION
## Overview

I've added tests for handling incorrect path formats and empty objects, and improved the descriptions for clarity. 

- Include test to handle paths with consecutive dots in the get function.
- Add test for get function with empty object inputs.
- Implement test for set function to handle incorrect path formats.
- Add test case for set function with empty object inputs.

These tests enhance the robustness of get and set functions by covering additional edge cases

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
