### PR TITLE
docs(@toss/utils): fix code example of formatToKRW

### DIFF
--- a/packages/common/utils/src/Numbers_formatToKRW.en.md
+++ b/packages/common/utils/src/Numbers_formatToKRW.en.md
@@ -26,7 +26,7 @@ function formatToKRW(
 
 ```typescript
 formatToKRW(13209802); // '1,320만 9,802원'
-formatToKRW(13209802, { floorUnit: 10000 }); // '1,320만 원'
-formatToKRW(13209802, { ceilUnit: 10000 }); // '1,321만 원'
-formatToKRW(13200000, { formatAllDigits: true }); // '천3백2십만 원'
+formatToKRW(13209802, { floorUnit: 10000 }); // '1,320만원'
+formatToKRW(13209802, { ceilUnit: 10000 }); // '1,320만 9,802원'
+formatToKRW(13200000, { formatAllDigits: true }); // '천3백2십만원'
 ```


### PR DESCRIPTION
## Overview

`shouldHaveSpaceBeforeWon` is not provided as options. so it will returned `${formattedVal}원`.

Also ceilUnit are not working. pr on fix(@toss/utils): ceilUnit parameter was missing #371 


## PR Checklist

- [✅] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
