### PR TITLE
test(@toss/utils): reinforce clipboard uncovered line

### DIFF
--- a/packages/common/utils/src/clipboard.spec.ts
+++ b/packages/common/utils/src/clipboard.spec.ts
@@ -24,12 +24,12 @@ function mockNavigator(mock: FakeNavigator) {
   fakeNavigator = mock;
 }
 
-describe('clipboard는', () => {
+describe('clipboard', () => {
   afterEach(() => {
     clearNavigator();
   });
 
-  test('writeText로 클립보드에 텍스트를 입력할 수 있다.', async () => {
+  it('should be able to enter text into the clipboard', async () => {
     mockNavigator({
       clipboard: {
         writeText: jest.fn(),
@@ -37,12 +37,12 @@ describe('clipboard는', () => {
     });
 
     const spy = jest.spyOn(navigator.clipboard, 'writeText');
-    const success = await clipboard.writeText('카피');
+    const success = await clipboard.writeText('copy!');
     expect(spy).toHaveBeenCalled();
     expect(success).toBe(true);
   });
 
-  test('IE에서는 writeText 대신 execCommand 한다.', async () => {
+  it('should use execCommand instead of writeText in IE', async () => {
     document.queryCommandSupported = jest.fn(command => command === 'copy');
     document.execCommand = jest.fn();
 
@@ -51,8 +51,24 @@ describe('clipboard는', () => {
     });
 
     const spy = jest.spyOn(document, 'execCommand');
-    const success = await clipboard.writeText('IE 카피');
+    const success = await clipboard.writeText('IE copy!');
     expect(spy).toHaveBeenCalled();
     expect(success).toBe(true);
+  });
+
+  it('should execute the catch block in case of failure', async () => {
+    mockNavigator({
+      clipboard: {
+        writeText: jest.fn().mockRejectedValue(new Error('Clipboard write failed')),
+      },
+      userAgent: 'user agent',
+    });
+
+    document.queryCommandSupported = jest.fn(command => command !== 'copy');
+
+    const writeTextSpy = jest.spyOn(navigator.clipboard, 'writeText');
+    const fail = await clipboard.writeText('copy!');
+    expect(writeTextSpy).toHaveBeenCalled();
+    expect(fail).toBe(false);
   });
 });


### PR DESCRIPTION
## Overview

[ What did i do ]

1. reinforce uncovered line in `clipboard.ts`

[ before ]
<img width="644" alt="스크린샷 2023-12-06 오후 10 42 28" src="https://github.com/toss/slash/assets/55759551/4ac4686d-f49c-428e-a6dd-d5aab4bd29d4">

[ after ]
<img width="644" alt="스크린샷 2023-12-06 오후 10 39 08" src="https://github.com/toss/slash/assets/55759551/fc69ef58-3d55-423f-bb3f-19cb8adfb7e6">


## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
3. I have written documents and tests, if needed.
