### PR TITLE
feat(@toss/utils): Translate tests codes for `escapeHTML` and update docs to match parameter name

### DIFF
--- a/packages/common/utils/src/escapeHTML.en.md
+++ b/packages/common/utils/src/escapeHTML.en.md
@@ -1,7 +1,7 @@
 # escapeHTML
 
 ```typescript
-function escapeHTML(str: string): string;
+function escapeHTML(text: string): string;
 ```
 
 Replaces a special character with an HTML entity.

--- a/packages/common/utils/src/escapeHTML.ko.md
+++ b/packages/common/utils/src/escapeHTML.ko.md
@@ -1,7 +1,7 @@
 # escapeHTML
 
 ```typescript
-function escapeHTML(str: string): string;
+function escapeHTML(text: string): string;
 ```
 
 특수 문자를 HTML 엔티티로 치환해 줍니다.

--- a/packages/common/utils/src/escapeHTML.spec.ts
+++ b/packages/common/utils/src/escapeHTML.spec.ts
@@ -1,19 +1,19 @@
 import { escapeHTML } from './escapeHTML';
 
-describe('escapeHTML은', () => {
-  it('텍스트에 포함된 특수문자를 치환하여 반환합니다.', () => {
-    const text1 = "'특수&문자'";
-    expect(escapeHTML(text1)).toBe('&#39;특수&amp;문자&#39;');
+describe('escapeHTML', () => {
+  it('should replace special characters in the text and return it', () => {
+    const REPLACED_TEXT = "'Tom&Jerry'";
+    expect(escapeHTML(REPLACED_TEXT)).toBe('&#39;Tom&amp;Jerry&#39;');
 
-    const text2 = '<테스트>';
-    expect(escapeHTML(text2)).toBe('&lt;테스트&gt;');
+    const REPLACED_TEXT2 = '<Test>';
+    expect(escapeHTML(REPLACED_TEXT2)).toBe('&lt;Test&gt;');
 
-    const text3 = '"테스트"';
-    expect(escapeHTML(text3)).toBe('&quot;테스트&quot;');
+    const REPLACED_TEXT3 = '"Test"';
+    expect(escapeHTML(REPLACED_TEXT3)).toBe('&quot;Test&quot;');
   });
 
-  it('텍스트에 특수문자가 포함되지 않았으면 텍스트를 그대로 반환합니다.', () => {
-    const text = '테스트';
-    expect(escapeHTML(text)).toBe('테스트');
+  it('should return the text as it is if there are no special characters', () => {
+    const REPLACED_TEXT = 'Test';
+    expect(escapeHTML(REPLACED_TEXT)).toBe('Test');
   });
 });


### PR DESCRIPTION
## Overview

[ What did i do ]
1. Match markdown's function parameter name and origin function parameter name.
2. Change korean to english in test code.

[ Proposal ]

The `default` case of the switch statement in "escapeHTML" can never be executed. That's because it's filtered out of "regex."

If default is not executed, it seems that the confusion of the code will only increase.
Can I change default to the 5th case?

You can refer [escapeHTML](https://github.com/toss/slash/blob/main/packages/common/utils/src/escapeHTML.ts).

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
4. I have written documents and tests, if needed.
