### PR TITLE
docs(@toss/utils) : Correct typos in Numbers

### DIFF
--- a/packages/common/utils/src/Numbers_formatBusinessRegistrationNumber.en.md
+++ b/packages/common/utils/src/Numbers_formatBusinessRegistrationNumber.en.md
@@ -5,7 +5,7 @@ sidebar_label: formatBusinessRegistrationNumber
 
 # formatBusinessRegistrationNumber
 
-Separates Korean corporate registration number by hypen(`-`).
+Separates Korean corporate registration number by hyphen(`-`).
 
 ```typescript
 function formatBusinessRegistrationNumber(businessRegistrationNumber: string): string;

--- a/packages/common/utils/src/Numbers_formatPhoneNumber.en.md
+++ b/packages/common/utils/src/Numbers_formatPhoneNumber.en.md
@@ -5,7 +5,7 @@ sidebar_label: formatPhoneNumber
 
 # formatPhoneNumber
 
-Separates the given phone number by hypen(`-`).
+Separates the given phone number by hyphen(`-`).
 
 ```typescript
 function formatPhoneNumber(phoneNumber: string): string;


### PR DESCRIPTION
## Overview

[ What did i do ]
1. Correct typos (hypen -> hyphen) in formatBusinessRegistrationNumber, formatPhoneNumber. You can referred [here](https://dictionary.cambridge.org/dictionary/english-korean/hyphen).

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
