### PR TITLE
docs(@toss/utils): fix typo in clamp docs

### DIFF
--- a/packages/common/utils/src/clamp.en.md
+++ b/packages/common/utils/src/clamp.en.md
@@ -16,7 +16,7 @@ function clamp(value: number, min: number, max: number): number;
 ## Examples
 
 ```typescript
-clamp(3, 1); // 3
+clamp(3, 1); // 1
 clamp(3, 1, 5); // 3
 clamp(3, 5); // 3
 clamp(7, 3, 5); // 5

--- a/packages/common/utils/src/clamp.ko.md
+++ b/packages/common/utils/src/clamp.ko.md
@@ -16,7 +16,7 @@ function clamp(value: number, min: number, max: number): number;
 ## Examples
 
 ```typescript
-clamp(3, 1); // 3
+clamp(3, 1); // 1
 clamp(3, 1, 5); // 3
 clamp(3, 5); // 3
 clamp(7, 3, 5); // 5


### PR DESCRIPTION
## Overview

[ What did i do ]
1. I change some comment in docs. Beacuse, `clamp(3, 1)` actually return **1**. But, `chunk.\*.md` returns **3**.

## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
