### PR TITLE
test(@toss/utils): Improve tests for get-set

### DIFF
--- a/packages/common/utils/src/get-set.spec.ts
+++ b/packages/common/utils/src/get-set.spec.ts
@@ -23,18 +23,6 @@ describe('get function', () => {
     expect(get(obj, 'a.c')).toBeNull();
     expect(get(obj, 'a.b.d')).toBeUndefined();
   });
-
-  it('should handle mixed array and object structures', () => {
-    const obj = { a: [{ b: { c: 1 } }, { d: 2 }] };
-    expect(get(obj, 'a[0].b.c')).toBe(1);
-    expect(get(obj, 'a[1].d')).toBe(2);
-  });
-
-  it('should return undefined when the path is empty', () => {
-    const obj = { a: { b: { c: 'd' } } };
-
-    expect(get(obj, '')).toBeUndefined();
-  });
 });
 
 describe('set function', () => {

--- a/packages/common/utils/src/get-set.spec.ts
+++ b/packages/common/utils/src/get-set.spec.ts
@@ -1,27 +1,32 @@
 import { get, set } from './get-set';
 
 describe('get function', () => {
-  it('should correctly retrieve a value for a single-level property', () => {
-    expect(get({ a: { b: { c: 'd' } } }, 'a')).toStrictEqual({ b: { c: 'd' } });
+  describe('Returns a valid value.', () => {
+    it('should correctly retrieve a value for a single-level property', () => {
+      expect(get({ a: { b: { c: 'd' } } }, 'a')).toStrictEqual({ b: { c: 'd' } });
+    });
+    it('should correctly retrieve a value for a multi-level property', () => {
+      expect(get({ a: { b: { c: 'd' } } }, 'a.b')).toStrictEqual({ c: 'd' });
+      expect(get({ a: { b: { c: 'd' } } }, 'a.b.c')).toStrictEqual('d');
+    });
+    it('should return a default value when the specified path does not exist', () => {
+      expect(get({ a: { b: { c: 'd' } } }, 'a.c', 'default')).toStrictEqual('default');
+    });
+    it('should ignore consecutive dots in path and retrieve the correct value', () => {
+      expect(get({ a: { b: { c: 'd' } } }, 'a..b')).toStrictEqual({ c: 'd' });
+    });
   });
-  it('should correctly retrieve a value for a multi-level property', () => {
-    expect(get({ a: { b: { c: 'd' } } }, 'a.b')).toStrictEqual({ c: 'd' });
-    expect(get({ a: { b: { c: 'd' } } }, 'a.b.c')).toStrictEqual('d');
-  });
-  it('should return a default value when the specified path does not exist', () => {
-    expect(get({ a: { b: { c: 'd' } } }, 'a.c', 'default')).toStrictEqual('default');
-  });
-  it('should ignore consecutive dots in path and retrieve the correct value', () => {
-    expect(get({ a: { b: { c: 'd' } } }, 'a..b')).toStrictEqual({ c: 'd' });
-  });
-  it('should work correctly with empty objects', () => {
-    expect(get({}, 'a')).toBeUndefined();
-  });
-  it('should handle paths leading to undefined or null values inside nested objects', () => {
-    const obj = { a: { b: undefined, c: null } };
-    expect(get(obj, 'a.b')).toBeUndefined();
-    expect(get(obj, 'a.c')).toBeNull();
-    expect(get(obj, 'a.b.d')).toBeUndefined();
+
+  describe('Returns null or undefined', () => {
+    it('should work correctly with empty objects', () => {
+      expect(get({}, 'a')).toBeUndefined();
+    });
+    it('should handle paths leading to undefined or null values inside nested objects', () => {
+      const obj = { a: { b: undefined, c: null } };
+      expect(get(obj, 'a.b')).toBeUndefined();
+      expect(get(obj, 'a.c')).toBeNull();
+      expect(get(obj, 'a.b.d')).toBeUndefined();
+    });
   });
 });
 

--- a/packages/common/utils/src/get-set.spec.ts
+++ b/packages/common/utils/src/get-set.spec.ts
@@ -17,6 +17,24 @@ describe('get function', () => {
   it('should work correctly with empty objects', () => {
     expect(get({}, 'a')).toBeUndefined();
   });
+  it('should handle paths leading to undefined or null values inside nested objects', () => {
+    const obj = { a: { b: undefined, c: null } };
+    expect(get(obj, 'a.b')).toBeUndefined();
+    expect(get(obj, 'a.c')).toBeNull();
+    expect(get(obj, 'a.b.d')).toBeUndefined();
+  });
+
+  it('should handle mixed array and object structures', () => {
+    const obj = { a: [{ b: { c: 1 } }, { d: 2 }] };
+    expect(get(obj, 'a[0].b.c')).toBe(1);
+    expect(get(obj, 'a[1].d')).toBe(2);
+  });
+
+  it('should return undefined when the path is empty', () => {
+    const obj = { a: { b: { c: 'd' } } };
+
+    expect(get(obj, '')).toBeUndefined();
+  });
 });
 
 describe('set function', () => {


### PR DESCRIPTION
## Overview

[ What did i do ]

1. Improve get-set's uncovered line.

[ Before ]
<img width="561" alt="스크린샷 2023-12-11 오후 3 53 48" src="https://github.com/toss/slash/assets/55759551/4edcaf3a-8673-4b04-bcfc-1dfe2f2e94d5">

[ After ] 
<img width="561" alt="스크린샷 2023-12-11 오후 3 52 32" src="https://github.com/toss/slash/assets/55759551/3e000675-777c-4924-bf97-6f4af34c6f6c">

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
3. I have written documents and tests, if needed.
