### PR TITLE
fix(use-funnel): use strict equal operator

### DIFF
--- a/packages/react/use-funnel/src/Funnel.tsx
+++ b/packages/react/use-funnel/src/Funnel.tsx
@@ -18,7 +18,7 @@ export const Funnel = <Steps extends NonEmptyArray<string>>({ steps, step, child
 
   const targetStep = validChildren.find(child => child.props.name === step);
 
-  assert(targetStep != null, `${step} 스텝 컴포넌트를 찾지 못했습니다.`);
+  assert(targetStep !== null, `${step} 스텝 컴포넌트를 찾지 못했습니다.`);
 
   return <>{targetStep}</>;
 };


### PR DESCRIPTION
## Overview

The logic that previously used the default not equal operator to determine  
whether targetStep is null was replaced with the strict equal operator.

## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
