### PR TITLE
chore(.gitignore): add coverage to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ esm
 node_modules
 junit.xml
 *.tossdocs.md
+coverage


### PR DESCRIPTION
## Overview
add coverage to gitignore

Each time a coverage test is conducted, the commitment history contains the contents within the coverage folder, which has an unnecessary impact on the task

## AS-IS
![image](https://github.com/toss/slash/assets/102217654/8efb67d0-fec6-4d2e-928e-774f4b7d0526)

## TO-BE
![image](https://github.com/toss/slash/assets/102217654/61bef3db-0c00-44db-bbc0-7ded2c155e06)
<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
