### PR TITLE
test(@toss/emotion-utils): improve flex test coverage

### DIFF
--- a/packages/react/emotion-utils/src/flex.test.tsx
+++ b/packages/react/emotion-utils/src/flex.test.tsx
@@ -3,7 +3,7 @@
 import { render, renderHook } from '@testing-library/react';
 import { useRef } from 'react';
 
-import { Flex } from './flex';
+import { flex, Flex } from './flex';
 
 describe('Flex', () => {
   describe('as', () => {
@@ -93,6 +93,67 @@ describe('Flex', () => {
       );
 
       expect(ref.current).not.toBeNull();
+    });
+  });
+
+  describe('flex', () => {
+    it('should render default flex style', () => {
+      const { container } = render(<div css={flex({})}>text</div>);
+
+      const flexDefaultStyle = {
+        justifyContent: 'flex-start',
+        flexDirection: 'row',
+      };
+
+      expect(container.querySelector('div')).toHaveStyle(flexDefaultStyle);
+    });
+
+    it('should render flex with align-items: center', () => {
+      const { container } = render(<div css={flex({ align: 'center' })}>text</div>);
+
+      expect(container.querySelector('div')).toHaveStyle('align-items: center');
+    });
+
+    it('should render flex center', () => {
+      const { container } = render(<div css={flex.center()}>text</div>);
+
+      const flexStyle = {
+        alignItems: 'center',
+        justifyContent: 'center',
+      };
+
+      expect(container.querySelector('div')).toHaveStyle(flexStyle);
+    });
+
+    it('should render non-object flex style', () => {
+      const { container } = render(<div css={flex('center', 'center')}>text</div>);
+
+      const flexStyle = {
+        alignItems: 'center',
+        justifyContent: 'center',
+      };
+
+      expect(container.querySelector('div')).toHaveStyle(flexStyle);
+    });
+  });
+
+  describe('Flex', () => {
+    it('should render Flex.CenterHorizontal', () => {
+      const { container } = render(<Flex.CenterHorizontal>text</Flex.CenterHorizontal>);
+
+      expect(container.querySelector('div')).toHaveStyle('justify-content: center');
+    });
+
+    it('should render default style', () => {
+      const { container } = render(<Flex>text</Flex>);
+
+      const flexStyle = {
+        flexDirection: 'row',
+        alignItems: 'stretch',
+        justifyContent: 'flex-start',
+      };
+
+      expect(container.querySelector('div')).toHaveStyle(flexStyle);
     });
   });
 });


### PR DESCRIPTION
## Overview
improve flex test coverage

## AS-IS
<img width="486" alt="image" src="https://github.com/toss/slash/assets/102217654/916db168-4efd-4f9b-a9ca-7856d2a838d4">

## TO-BE
<img width="462" alt="image" src="https://github.com/toss/slash/assets/102217654/10657a6a-4d55-443a-a1f8-8ba898ec4b0a">
<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
