### PR TITLE
test(@toss/utils): improve test for formatToKoreanNumber

### DIFF
--- a/packages/common/utils/src/Numbers.spec.ts
+++ b/packages/common/utils/src/Numbers.spec.ts
@@ -51,12 +51,17 @@ describe('Numbers', () => {
     expect(formatToKoreanNumber(13209802)).toBe('1,320만 9,802');
     expect(formatToKoreanNumber(200000)).toBe('20만');
     expect(formatToKoreanNumber(100000000)).toBe('1억');
+    expect(formatToKoreanNumber(0)).toBe('0');
     expect(
       formatToKoreanNumber(12000, {
         formatAllDigits: true,
       })
     ).toBe('만 2천');
-    expect(formatToKoreanNumber(0)).toBe('0');
+    expect(
+      formatToKoreanNumber(840000, {
+        floorUnit: 0,
+      })
+    ).toBe('84만');
   });
 
   it('should format the given number into korean currency format', () => {
@@ -67,13 +72,13 @@ describe('Numbers', () => {
       })
     ).toEqual('1,320만 9,802 원');
     expect(
-      formatToKRW(13209802, { 
-        floorUnit: 10000 
+      formatToKRW(13209802, {
+        floorUnit: 10000,
       })
     ).toEqual('1,320만원');
     expect(
-      formatToKRW(13209802, { 
-        ceilUnit: 10000 
+      formatToKRW(13209802, {
+        ceilUnit: 10000,
       })
     ).toEqual('1,321만원');
   });


### PR DESCRIPTION
## Overview

[ What did i do ]
'Uncovered line' has been added due to [changed code](https://github.com/toss/slash/pull/371/files#diff-8bcab93973b45d4060faa3f177cfbf408f541e314a52d915b6608345e97952db). So I improved it.

[ AS-IS ]
<img width="632" alt="image" src="https://github.com/toss/slash/assets/55759551/35a31c27-5f7f-4837-97b5-8b0cb10096c0">

[ TO-BE ]
<img width="654" alt="image" src="https://github.com/toss/slash/assets/55759551/6c4de4cc-8339-4c33-b3d3-7ddb3aa9be0b">


## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
3. I have written documents and tests, if needed.
