### PR TITLE
fix(@toss/validators): Increase the accuracy of verification

### DIFF
--- a/packages/common/validators/src/validators/is-birth-date-6.spec.ts
+++ b/packages/common/validators/src/validators/is-birth-date-6.spec.ts
@@ -11,6 +11,8 @@ describe('isBirthDate6', () => {
     expect(isBirthDate6('foobar')).toEqual(false);
     expect(isBirthDate6('000000')).toEqual(false);
     expect(isBirthDate6('960732')).toEqual(false);
+    expect(isBirthDate6('951301')).toEqual(false);
+    expect(isBirthDate6('950231')).toEqual(false);
     expect(isBirthDate6('')).toEqual(false);
   });
 });

--- a/packages/common/validators/src/validators/is-birth-date-6.ts
+++ b/packages/common/validators/src/validators/is-birth-date-6.ts
@@ -1,5 +1,27 @@
 /** @tossdocs-ignore */
 export function isBirthDate6(birthDate: string) {
-  const re = /^[0-9]{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[1,2][0-9]|3[0,1])$/;
-  return re.test(birthDate);
+  if (!/^\d{6}$/.test(birthDate)) {
+    return false;
+  }
+
+  const year = parseInt(birthDate.substring(0, 2), 10);
+  const month = parseInt(birthDate.substring(2, 4), 10);
+  const day = parseInt(birthDate.substring(4, 6), 10);
+
+  if (month < 1 || month > 12) {
+    return false;
+  }
+
+  const daysInFebruary = isLeapYear(year) ? 29 : 28;
+  const daysInMonth = [31, daysInFebruary, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+  if (day < 1 || day > daysInMonth[month - 1]) {
+    return false;
+  }
+
+  return true;
+}
+
+function isLeapYear(year: number) {
+  return year !== 0 && year % 4 === 0;
 }


### PR DESCRIPTION
## Overview

[ What did i do ]
According to the Gregorian calendar, there are months when 30 or 31 days do not exist. For example, February 30 and April 31.
The current "isBirthDate6" is not responsible for this, even though it is a function to verify the correct date of birth. So I've supplemented this.

[ Problem ]
<img width="411" alt="image" src="https://github.com/toss/slash/assets/55759551/408b942a-a6aa-4c72-876e-c25a3c8ca725">

[ TO-BE ]
```ts
expect(isBirthDate6('950230')).toEqual(false);
expect(isBirthDate6('950431')).toEqual(false);
```
<img width="483" alt="image" src="https://github.com/toss/slash/assets/55759551/c979fc80-aff1-412f-8ad7-e3adb2734640">


## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
