### PR TITLE
feat(@toss/utils): Add iterateEnum util function

### DIFF
--- a/packages/common/utils/src/iterateEnum.en.md
+++ b/packages/common/utils/src/iterateEnum.en.md
@@ -1,0 +1,19 @@
+# iterateEnum
+
+Ensures accurate type inference when iterating over enum types.
+
+## Example
+
+```typescript
+enum Language {
+  KOR = 'KOR',
+  ENG = 'ENG',
+  JPN = 'JPN',
+}
+
+// When using Object.keys method to iterate over the enum, the type inference is string.
+const arr1 = Object.keys(Language); // string[]
+
+// With iterateEnum, accurate type inference to the enum type is possible without type assertion.
+iterateEnum(Language); // Language[]
+```

--- a/packages/common/utils/src/iterateEnum.ko.md
+++ b/packages/common/utils/src/iterateEnum.ko.md
@@ -1,0 +1,19 @@
+# iterateEnum
+
+enum 타입을 순회할 때 정확한 타입 추론이 되도록 합니다.
+
+## Example
+
+```typescript
+enum Language {
+  KOR = 'KOR',
+  ENG = 'ENG',
+  JPN = 'JPN',
+}
+
+// Object.keys 메서드를 사용해서 이넘을 순회하는 경우 string으로 타입 추론합니다.
+const arr1 = Object.keys(Language); // string[]
+
+// iterateEnum을 사용하면 type assertion 없이 해당 enum 타입으로 정확한 타입 추론이 가능합니다.
+iterateEnum(Language); // Language[]
+```

--- a/packages/common/utils/src/iterateEnum.spec.ts
+++ b/packages/common/utils/src/iterateEnum.spec.ts
@@ -1,3 +1,5 @@
+import { iterateEnum } from './iterateEnum';
+
 enum Language {
   KOR = 'KOR',
   ENG = 'ENG',

--- a/packages/common/utils/src/iterateEnum.spec.ts
+++ b/packages/common/utils/src/iterateEnum.spec.ts
@@ -6,17 +6,23 @@ enum Language {
   JPN = 'JPN',
 }
 
+enum LanguageNum {
+  KOR = 1,
+  ENG = 2,
+  JPN = 3,
+}
+
 export default describe('iterateEnum', () => {
-  it('should iterate over enum correctly', () => {
+  it('should iterate over string enum correctly', () => {
     const expectedArray = [Language.KOR, Language.ENG, Language.JPN];
 
     expect(iterateEnum(Language)).toEqual(expectedArray);
   });
 
-  it('should produce the same result as Object.keys', () => {
-    const expectedArray = Object.keys(Language);
+  it('should iterate over number enum correctly', () => {
+    const expectedArray = ['KOR', 'ENG', 'JPN'];
 
-    expect(iterateEnum(Language)).toEqual(expectedArray);
+    expect(iterateEnum(LanguageNum)).toEqual(expectedArray);
   });
 
   it('should infer the correct type', () => {

--- a/packages/common/utils/src/iterateEnum.spec.ts
+++ b/packages/common/utils/src/iterateEnum.spec.ts
@@ -19,7 +19,7 @@ export default describe('iterateEnum', () => {
     expect(iterateEnum(Language)).toEqual(expectedArray);
   });
 
-  it('should iterate over number enum correctly', () => {
+  it('should iterate over numeric enum correctly', () => {
     const expectedArray = ['KOR', 'ENG', 'JPN'];
 
     expect(iterateEnum(LanguageNum)).toEqual(expectedArray);

--- a/packages/common/utils/src/iterateEnum.spec.ts
+++ b/packages/common/utils/src/iterateEnum.spec.ts
@@ -1,0 +1,26 @@
+enum Language {
+  KOR = 'KOR',
+  ENG = 'ENG',
+  JPN = 'JPN',
+}
+
+export default describe('iterateEnum', () => {
+  it('should iterate over enum correctly', () => {
+    const expectedArray = [Language.KOR, Language.ENG, Language.JPN];
+
+    expect(iterateEnum(Language)).toEqual(expectedArray);
+  });
+
+  it('should produce the same result as Object.keys', () => {
+    const expectedArray = Object.keys(Language);
+
+    expect(iterateEnum(Language)).toEqual(expectedArray);
+  });
+
+  it('should infer the correct type', () => {
+    const result = iterateEnum(Language);
+    const typeCheck: Language[] = result;
+
+    expect(typeCheck).toBeTruthy();
+  });
+});

--- a/packages/common/utils/src/iterateEnum.ts
+++ b/packages/common/utils/src/iterateEnum.ts
@@ -1,0 +1,5 @@
+export function iterateEnum<EnumObjectValueType>(
+  enumObject: Record<string, EnumObjectValueType>
+): EnumObjectValueType[] {
+  return Object.values(enumObject);
+}

--- a/packages/common/utils/src/iterateEnum.ts
+++ b/packages/common/utils/src/iterateEnum.ts
@@ -1,5 +1,5 @@
 export function iterateEnum<EnumObjectValueType>(
   enumObject: Record<string, EnumObjectValueType>
 ): EnumObjectValueType[] {
-  return Object.values(enumObject);
+  return Object.values(enumObject).filter(value => typeof value !== 'number');
 }


### PR DESCRIPTION
## Overview
Add iterateEnum util function to `@toss/utils`

When using Object.keys method to iterate over the enum, the type inference is string.
```
const arr1 = Object.keys(Language); // string[]
```

With iterateEnum, accurate type inference to the enum type is possible without type assertion.
```
iterateEnum(Language); // Language[]
```

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
