### PR TITLE
docs(@toss/redirect): add documentation for RedirectionBoundary

### DIFF
--- a/packages/react/redirect/src/base/boundary/RedirectionBoundary.en.md
+++ b/packages/react/redirect/src/base/boundary/RedirectionBoundary.en.md
@@ -1,0 +1,33 @@
+---
+title: RedirectionBoundary
+---
+
+# RedirectionBoundary
+
+A component that handles Redirection exceptions.
+The `RedirectionBoundary` component captures any `Redirection` exceptions thrown by its children and facilitates redirection to specific routes.
+
+By utilizing the `RedirectionBoundary` component, you can manage redirection logic declaratively within the component tree, allowing for seamless navigation between different parts of your application based on URL paths.
+
+## Example
+
+```jsx
+const Example = () => {
+  if (!isLoggedIn) {
+    throw Redirection.of({ destination: 'login' });
+  }
+  return <></>;
+};
+
+export const Component = () => {
+  return (
+    <RedirectionBoundary
+      onRedirect={redirection => {
+        window.location.href = redirection.options.destination;
+      }}
+    >
+      <Example />
+    </RedirectionBoundary>
+  );
+};
+```

--- a/packages/react/redirect/src/base/boundary/RedirectionBoundary.ko.md
+++ b/packages/react/redirect/src/base/boundary/RedirectionBoundary.ko.md
@@ -1,0 +1,33 @@
+---
+title: RedirectionBoundary
+---
+
+# RedirectionBoundary
+
+Redirection 예외를 처리하는 컴포넌트입니다.
+`RedirectionBoundary` 컴포넌트는 children 발생하는 `Redirection` 예외를 캡처하고, 특정 경로(route)로의 redirection 을 처리합니다.
+
+`RedirectionBoundary` 컴포넌트를 사용함으로써, redirection 로직을 컴포넌트 트리 내에서 선언적으로 관리할 수 있게 됩니다.
+
+## Example
+
+```jsx
+const Example = () => {
+  if (!isLoggedIn) {
+    throw Redirection.of({ destination: 'login' });
+  }
+  return <></>;
+};
+
+export const Component = () => {
+  return (
+    <RedirectionBoundary
+      onRedirect={redirection => {
+        window.location.href = redirection.options.destination;
+      }}
+    >
+      <Example />
+    </RedirectionBoundary>
+  );
+};
+```

--- a/packages/react/redirect/src/base/boundary/RedirectionBoundary.tsx
+++ b/packages/react/redirect/src/base/boundary/RedirectionBoundary.tsx
@@ -1,3 +1,4 @@
+/** @tossdocs-ignore */
 import { assert } from '@toss/assert';
 import { ErrorBoundary } from '@toss/error-boundary';
 import { ReactNode } from 'react';


### PR DESCRIPTION
## Overview

The RedirectionBoundary component is not documented, so I documented it in ko and en.
![image](https://github.com/toss/slash/assets/52266597/5328275a-810f-4262-98f5-c2bfa4dba4b9)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
