### PR TITLE
test(@toss/utils): Add new test for getViewportSize

### DIFF
--- a/packages/common/utils/src/getViewportSize.spec.ts
+++ b/packages/common/utils/src/getViewportSize.spec.ts
@@ -1,0 +1,23 @@
+import * as deviceModule from './device/isServer';
+import { getViewportSize } from './getViewportSize';
+
+describe('getViewportSize', () => {
+  it('returns width and height as 0 in server environments.', () => {
+    jest.spyOn(deviceModule, 'isServer').mockReturnValue(true);
+
+    const size = getViewportSize();
+    expect(size).toEqual({ width: 0, height: 0 });
+    jest.spyOn(deviceModule, 'isServer').mockRestore();
+  });
+
+  it('returns window.innerWidth and window.innerHeight in client environments.', () => {
+    jest.spyOn(deviceModule, 'isServer').mockReturnValue(false);
+
+    Object.defineProperty(window, 'innerWidth', { value: 300 });
+    Object.defineProperty(window, 'innerHeight', { value: 500 });
+
+    const size = getViewportSize();
+    expect(size).toEqual({ width: 300, height: 500 });
+    jest.spyOn(deviceModule, 'isServer').mockRestore();
+  });
+});


### PR DESCRIPTION
## Overview

I wrote test code for the getViewportSize function

[AS-IS]
![스크린샷 2024-02-21 오후 6 46 54](https://github.com/toss/slash/assets/52266597/5e08ae1e-5ff9-44ef-b34c-47e023c136c0)

[TO-BE]
![스크린샷 2024-02-21 오후 6 47 40](https://github.com/toss/slash/assets/52266597/6060fd78-e4a0-40c8-b90f-fff1c9fd53dd)


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
