### PR TITLE
test(@toss/react): useInterval hook test, changed to English, improved scope

### DIFF
--- a/packages/react/react/src/hooks/useInterval.spec.tsx
+++ b/packages/react/react/src/hooks/useInterval.spec.tsx
@@ -43,4 +43,22 @@ describe('useInterval', () => {
 
     expect(callback).toBeCalledTimes(2);
   });
+
+  it('Should not set the interval when delay is null.', () => {
+    const callback = jest.fn();
+
+    renderHook(() => useInterval(callback, { delay: null }));
+
+    jest.advanceTimersByTime(3000);
+
+    expect(callback).not.toBeCalled();
+  });
+
+  it('Should execute the callback immediately when the trailing option is false.', () => {
+    const callback = jest.fn();
+
+    renderHook(() => useInterval(callback, { delay: 3000, trailing: false }));
+
+    expect(callback).toBeCalledTimes(1);
+  });
 });

--- a/packages/react/react/src/hooks/useInterval.spec.tsx
+++ b/packages/react/react/src/hooks/useInterval.spec.tsx
@@ -4,7 +4,7 @@ import { useInterval } from './useInterval';
 jest.useFakeTimers();
 
 describe('useInterval', () => {
-  it('정해진 시간이 지날때마다, 콜백을 실행한다', () => {
+  it('Should execute a callback every time a set time passes.', () => {
     const callback = jest.fn();
 
     renderHook(() =>
@@ -26,7 +26,7 @@ describe('useInterval', () => {
     expect(callback).toBeCalledTimes(2);
   });
 
-  it('number option도 동일하게실행한다', () => {
+  it('should work the same with number options as well.', () => {
     const callback = jest.fn();
 
     renderHook(() => useInterval(callback, 3000));


### PR DESCRIPTION
## Overview

Changed Korean to English for useInterval Hook and improved coverage.

[AS-IS]
![스크린샷 2024-02-22 오후 11 56 53](https://github.com/toss/slash/assets/52266597/56079fee-e74a-4a87-8241-cf0baa59760c)

[TO-BE]
![스크린샷 2024-02-23 오전 12 03 15](https://github.com/toss/slash/assets/52266597/6404af65-a44d-48e3-a229-422e00c32178)

## PR Checklist

- [x] I read and included theses actions below
1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
