### PR TITLE
fix(@toss/utils): change inequality operator to strict inequallity operator

### DIFF
--- a/packages/common/utils/src/device/isAndroid.ts
+++ b/packages/common/utils/src/device/isAndroid.ts
@@ -5,5 +5,5 @@ export function isAndroid() {
     return false;
   }
 
-  return navigator.userAgent.match(/Android/i) != null;
+  return navigator.userAgent.match(/Android/i) !== null;
 }

--- a/packages/common/utils/src/device/isIOS.ts
+++ b/packages/common/utils/src/device/isIOS.ts
@@ -5,5 +5,5 @@ export function isIOS() {
     return false;
   }
 
-  return navigator.userAgent.match(/ipad|iphone/i) != null;
+  return navigator.userAgent.match(/ipad|iphone/i) !== null;
 }

--- a/packages/common/utils/src/device/isMacOS.ts
+++ b/packages/common/utils/src/device/isMacOS.ts
@@ -6,5 +6,5 @@ export function isMacOS() {
     return false;
   }
 
-  return navigator.platform.match(/Macintosh|MacIntel|MacPPC|Mac68K/) != null;
+  return navigator.platform.match(/Macintosh|MacIntel|MacPPC|Mac68K/) !== null;
 }


### PR DESCRIPTION
## Overview
This PR includes changes in 
- `@toss/utils/device/isAndroid.ts`
- `@toss/utils/device/isIOS.ts`
- `@toss/utils/device/isMacOS.ts`

Since `String.prototype.match()` function only returns an `Array`or `null`, there's no need of using [inequality operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Inequality) instead of [strict inequality operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality).
To prevent future type-related issues, using strict inequality operator should be recommended.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
