### PR TITLE
fix(@toss/storage): Fix boolean type inference for TypedStorage 

### DIFF
--- a/packages/common/storage/src/typed/factory.ts
+++ b/packages/common/storage/src/typed/factory.ts
@@ -4,7 +4,10 @@ import { NumberTypedStorage, TypedStorage, TypedStorageOptions } from './storage
 
 type Result<T> = T extends number ? NumberTypedStorage : TypedStorage<T>;
 
-function createTypedStorage<T>(key: string, options: TypedStorageOptions<T> = {}): Result<T> {
+function createTypedStorage<T>(
+  key: string,
+  options: TypedStorageOptions<T extends boolean ? boolean : T> = {}
+): Result<T> {
   const { initialValue, ...others } = options;
 
   if (typeof initialValue === 'number') {
@@ -14,10 +17,16 @@ function createTypedStorage<T>(key: string, options: TypedStorageOptions<T> = {}
   return new TypedStorage(key, options) as any;
 }
 
-export function createTypedLocalStorage<T>(key: string, options: Omit<TypedStorageOptions<T>, 'storage'> = {}) {
+export function createTypedLocalStorage<T>(
+  key: string,
+  options: Omit<TypedStorageOptions<T extends boolean ? boolean : T>, 'storage'> = {}
+) {
   return createTypedStorage<T>(key, { ...options, storage: safeLocalStorage });
 }
 
-export function createTypedSessionStorage<T>(key: string, options: Omit<TypedStorageOptions<T>, 'storage'> = {}) {
+export function createTypedSessionStorage<T>(
+  key: string,
+  options: Omit<TypedStorageOptions<T extends boolean ? boolean : T>, 'storage'> = {}
+) {
   return createTypedStorage<T>(key, { ...options, storage: safeSessionStorage });
 }

--- a/packages/common/storage/src/typed/storages/TypedStorage.spec.ts
+++ b/packages/common/storage/src/typed/storages/TypedStorage.spec.ts
@@ -35,7 +35,7 @@ describe('TypedStorage', () => {
       const key = 'set-boolean-test-key';
       const typed = new TypedStorage(key, { initialValue: false });
       typed.set(true);
-      expect(typed.get()).toEqual(false);
+      expect(typed.get()).toEqual(true);
       expect(typeof typed.get()).toEqual('boolean');
     });
   });

--- a/packages/common/storage/src/typed/storages/TypedStorage.spec.ts
+++ b/packages/common/storage/src/typed/storages/TypedStorage.spec.ts
@@ -30,6 +30,14 @@ describe('TypedStorage', () => {
       typed.set('changed-value');
       expect(typed.get()).toEqual('changed-value');
     });
+
+    it('should return boolean type for boolean initialValue', () => {
+      const key = 'set-boolean-test-key';
+      const typed = new TypedStorage(key, { initialValue: false });
+      typed.set(true);
+      expect(typed.get()).toEqual(false);
+      expect(typeof typed.get()).toEqual('boolean');
+    });
   });
 
   describe('using clear() method', () => {

--- a/packages/common/storage/src/typed/storages/TypedStorage.ts
+++ b/packages/common/storage/src/typed/storages/TypedStorage.ts
@@ -9,7 +9,7 @@ export interface TypedStorageOptions<T> {
 export class TypedStorage<T> {
   private storage: Storage;
 
-  constructor(private key: string, options: TypedStorageOptions<T> = {}) {
+  constructor(private key: string, options: TypedStorageOptions<T extends boolean ? boolean : T> = {}) {
     this.storage = options.storage ?? safeLocalStorage;
 
     if (options.initialValue != null && this.get() == null) {
@@ -22,7 +22,7 @@ export class TypedStorage<T> {
     return value ? this.deserialize(value) : null;
   }
 
-  public set(next: T): void {
+  public set(next: T extends boolean ? boolean : T): void {
     this.storage.set(this.key, this.serialize(next));
   }
 
@@ -30,7 +30,7 @@ export class TypedStorage<T> {
     this.storage.remove(this.key);
   }
 
-  private serialize(value: T): string {
+  private serialize(value: T extends boolean ? boolean : T): string {
     return JSON.stringify(value);
   }
 


### PR DESCRIPTION
## Overview

Fixes https://github.com/toss/slash/issues/428 and added test code.

Basically, I've changed the generic type `T` to `T extends boolean ? boolean : T`

## PR Checklist

- [✅] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
