### PR TITLE
chore: add repository information in package.json

### DIFF
--- a/configs/rollup/package.json
+++ b/configs/rollup/package.json
@@ -19,5 +19,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "configs/rollup"
+  },
   "gitHead": "6a4434621e29e014d537ae3dc0f026364b893a69"
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "packages/**/**",
     "configs/*"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git"
+  },
   "devDependencies": {
     "@babel/core": "^7.19.3",
     "@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/packages/common/assert/package.json
+++ b/packages/common/assert/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/assert"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/crypto/package.json
+++ b/packages/common/crypto/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/crypto"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/date/package.json
+++ b/packages/common/date/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/date"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/hangul/package.json
+++ b/packages/common/hangul/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/hangul"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/ky/package.json
+++ b/packages/common/ky/package.json
@@ -22,6 +22,11 @@
   "main": "./built/index.server.js",
   "types": "./built/index.server.d.ts",
   "react-native": "./built/index.browser.mjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/ky"
+  },
   "scripts": {
     "build": "bash ./scripts/build.sh",
     "prepack": "echo [Already built: yarn build로 수동 빌드할 수 있습니다.]",

--- a/packages/common/sentry/package.json
+++ b/packages/common/sentry/package.json
@@ -11,6 +11,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/sentry"
+  },
   "scripts": {
     "build": "concurrently \"tsc -p tsconfig.json\" \"tsc -p tsconfig.esm.json\"",
     "prepack": "yarn build",

--- a/packages/common/storage/package.json
+++ b/packages/common/storage/package.json
@@ -13,6 +13,11 @@
     "esm",
     "typed.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/storage"
+  },
   "scripts": {
     "build": "tsc --emitDeclarationOnly --outDir types && rollup -c && rm -rf types",
     "prepack": "yarn build",

--- a/packages/common/utility-types/package.json
+++ b/packages/common/utility-types/package.json
@@ -7,6 +7,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/utility-types"
+  },
   "scripts": {
     "build": "concurrently \"tsc -p tsconfig.json\" \"tsc -p tsconfig.esm.json\"",
     "prepack": "yarn build",

--- a/packages/common/utils/package.json
+++ b/packages/common/utils/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/utils"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/common/validators/package.json
+++ b/packages/common/validators/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/common/validators"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/a11y/package.json
+++ b/packages/react/a11y/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/a11y"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/async-boundary/package.json
+++ b/packages/react/async-boundary/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/async-boundary"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/async-stylesheet/package.json
+++ b/packages/react/async-stylesheet/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/async-stylesheet"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/emotion-utils/package.json
+++ b/packages/react/emotion-utils/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/emotion-utils"
+  },
   "scripts": {
     "prebuild": "rimraf dist esm",
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",

--- a/packages/react/error-boundary/package.json
+++ b/packages/react/error-boundary/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/error-boundary"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/framer-motion/package.json
+++ b/packages/react/framer-motion/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/framer-motion"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/impression-area/package.json
+++ b/packages/react/impression-area/package.json
@@ -12,6 +12,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/impression-area"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/lottie/package.json
+++ b/packages/react/lottie/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/lottie"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "lint": "yarn run -T eslint src/**/*.{js,ts,tsx}",

--- a/packages/react/react-query/package.json
+++ b/packages/react/react-query/package.json
@@ -18,6 +18,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/react-query"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build && yarn test:tsd",

--- a/packages/react/react/package.json
+++ b/packages/react/react/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/react"
+  },
   "scripts": {
     "build": "rm -rf dist/ && rm -rf esm/ && rollup -c && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist",
     "prepack": "yarn build",

--- a/packages/react/recoil/package.json
+++ b/packages/react/recoil/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/recoil"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/redirect/package.json
+++ b/packages/react/redirect/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/redirect"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/scroll-animation/package.json
+++ b/packages/react/scroll-animation/package.json
@@ -13,6 +13,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/scroll-animation"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/use-funnel/package.json
+++ b/packages/react/use-funnel/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/use-funnel"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/use-loading/package.json
+++ b/packages/react/use-loading/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/use-loading"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/use-overlay/package.json
+++ b/packages/react/use-overlay/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/use-overlay"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",

--- a/packages/react/use-query-param/package.json
+++ b/packages/react/use-query-param/package.json
@@ -14,6 +14,11 @@
     "dist",
     "esm"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toss/slash.git",
+    "directory": "packages/react/use-query-param"
+  },
   "scripts": {
     "build": "rm -rf dist esm && tsc -p tsconfig.build.json --declaration --emitDeclarationOnly --declarationDir dist && rollup -c rollup.config.js",
     "prepack": "yarn build",


### PR DESCRIPTION
## Overview
<!--
    A clear and concise description of what this pr is about.
 -->

Add the repository information to package.json. Developers who want to see the live code of the library can access toss slash github directly from this repository information. Various tools support the command, including git command and vscode extension

Reference Link
- [npm package json - repository field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
