### PR TITLE
fix(@toss/utils): Add 'Deno' in globalThis for isServer()

### DIFF
--- a/packages/common/utils/src/device/isServer.ts
+++ b/packages/common/utils/src/device/isServer.ts
@@ -1,3 +1,5 @@
+/** @tossdocs-ignore */
+
 export function isServer() {
   return typeof window === 'undefined' || 'Deno' in globalThis;
 }

--- a/packages/common/utils/src/device/isServer.ts
+++ b/packages/common/utils/src/device/isServer.ts
@@ -1,6 +1,3 @@
-/** @tossdocs-ignore */
-declare const global: unknown;
-
 export function isServer() {
-  return typeof window === 'undefined' && typeof global !== 'undefined';
+  return typeof window === 'undefined';
 }

--- a/packages/common/utils/src/device/isServer.ts
+++ b/packages/common/utils/src/device/isServer.ts
@@ -1,3 +1,3 @@
 export function isServer() {
-  return typeof window === 'undefined';
+  return typeof window === 'undefined' || 'Deno' in globalThis;
 }


### PR DESCRIPTION
## Overview

This PR makes two changes:
1. Removed `typeof global !== 'undefined'` according to [this issue](https://github.com/toss/slash/issues/352#issue-1953691398) and [this conversation](https://github.com/suspensive/react/pull/239#discussion_r1365379813)
2. Added `'Deno' in globalThis;`. [Tanstack/query](https://github.com/TanStack/query/blob/2ddf8036360279fcd6e3567859ec9c68fbfc024a/packages/query-core/src/utils.ts#L65) and [vercel/swr](https://github.com/vercel/swr/blob/cd22c46c4a0977e9d9afcd7b23f629e56e729344/src/_internal/utils/env.ts#L6) now use this checking for `isServer`. And we should use `globalThis` instead of `window` because it [became deprecated in Deno](https://github.com/denoland/deno/pull/22057).

## PR Checklist

- [✅] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
3. I have written documents and tests, if needed.
