### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# global reviewers
+@raon0211 @evan-moon @BasixKOR
+
+# @toss/hangul reviewers
+/packages/common/hangul @okinawaa
+


### PR DESCRIPTION
## Overview

To clarify the management responsibilities of the Slash library, a `CODEOWNERS` has been added.
Default reviewers for all code in this repository and reviewers with ownership of specific libraries (like `@toss/hangul`) have been added.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
