### PR TITLE
refactor(@toss/react): change to using usePreservedCallback

### DIFF
--- a/packages/react/react/src/hooks/useInterval.ts
+++ b/packages/react/react/src/hooks/useInterval.ts
@@ -10,10 +10,10 @@ type IntervalOptions =
     };
 
 /** @tossdocs-ignore */
-export function useInterval(callback = noop, options: IntervalOptions) {
+export function useInterval(callback: () => void, options: IntervalOptions) {
   const delay = typeof options === 'number' ? options : options.delay;
   const trailing = typeof options === 'number' ? undefined : options.trailing;
-  const savedCallback = usePreservedCallback(callback);
+  const savedCallback = usePreservedCallback(callback ?? noop);
 
   useEffect(() => {
     if (trailing === false) {

--- a/packages/react/react/src/hooks/usePreservedCallback.ts
+++ b/packages/react/react/src/hooks/usePreservedCallback.ts
@@ -8,10 +8,7 @@ export function usePreservedCallback<Callback extends (...args: any[]) => any>(c
     callbackRef.current = callback;
   }, [callback]);
 
-  return useCallback(
-    (...args: any[]) => {
-      return callbackRef.current(...args);
-    },
-    [callbackRef]
-  ) as Callback;
+  return useCallback((...args: any[]) => {
+    return callbackRef.current(...args);
+  }, []) as Callback;
 }

--- a/packages/react/react/src/hooks/useTimeout.ts
+++ b/packages/react/react/src/hooks/useTimeout.ts
@@ -1,24 +1,13 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
+import { usePreservedCallback } from './usePreservedCallback';
 
 /** @tossdocs-ignore */
 export function useTimeout(callback: () => void, delay = 0) {
-  const savedCallback = useRef<() => void>();
+  const savedCallback = usePreservedCallback(callback);
 
   useEffect(() => {
-    savedCallback.current = callback;
-  }, [callback]);
+    const timeoutId = window.setTimeout(savedCallback, delay);
 
-  useEffect(() => {
-    function handleTimeout() {
-      if (savedCallback.current) {
-        savedCallback.current();
-      }
-    }
-
-    const timeoutId = window.setTimeout(handleTimeout, delay);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [delay]);
+    return () => window.clearTimeout(timeoutId);
+  }, [delay, savedCallback]);
 }

--- a/packages/react/react/src/hooks/useTimeout.ts
+++ b/packages/react/react/src/hooks/useTimeout.ts
@@ -3,8 +3,8 @@ import { useEffect } from 'react';
 import { usePreservedCallback } from './usePreservedCallback';
 
 /** @tossdocs-ignore */
-export function useTimeout(callback = noop, delay = 0) {
-  const savedCallback = usePreservedCallback(callback);
+export function useTimeout(callback: () => void, delay = 0) {
+  const savedCallback = usePreservedCallback(callback ?? noop);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(savedCallback, delay);

--- a/packages/react/react/src/hooks/useTimeout.ts
+++ b/packages/react/react/src/hooks/useTimeout.ts
@@ -1,8 +1,9 @@
+import { noop } from '@toss/utils';
 import { useEffect } from 'react';
 import { usePreservedCallback } from './usePreservedCallback';
 
 /** @tossdocs-ignore */
-export function useTimeout(callback: () => void, delay = 0) {
+export function useTimeout(callback = noop, delay = 0) {
   const savedCallback = usePreservedCallback(callback);
 
   useEffect(() => {

--- a/packages/react/react/src/hooks/useVisibilityEvent.ts
+++ b/packages/react/react/src/hooks/useVisibilityEvent.ts
@@ -1,12 +1,13 @@
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
+import { usePreservedCallback } from './usePreservedCallback';
 
 type VisibilityState = Document['visibilityState'];
 
 /** @tossdocs-ignore */
 export function useVisibilityEvent(callback: (visibilityState: VisibilityState) => void) {
-  const handleVisibilityChange = useCallback(() => {
+  const handleVisibilityChange = usePreservedCallback(() => {
     callback(document.visibilityState);
-  }, [callback]);
+  });
 
   useEffect(() => {
     document.addEventListener('visibilitychange', handleVisibilityChange);


### PR DESCRIPTION
## Overview

We can use `usePreservedCallback` to keep a reference to the callback function and ensure that it is up to date. 

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
