### PR TITLE
fix(@toss/react): useOutsideClickEffect is called twice on touch event

### DIFF
--- a/packages/react/react/src/hooks/useOutsideClickEffect.ts
+++ b/packages/react/react/src/hooks/useOutsideClickEffect.ts
@@ -32,11 +32,9 @@ export function useOutsideClickEffect(container: OneOrMore<HTMLElement | null>, 
 
   useEffect(() => {
     document.addEventListener('click', handleDocumentClick);
-    document.addEventListener('touchstart', handleDocumentClick);
 
     return () => {
       document.removeEventListener('click', handleDocumentClick);
-      document.removeEventListener('touchstart', handleDocumentClick);
     };
   });
 }


### PR DESCRIPTION
## Overview

Fixes https://github.com/toss/slash/issues/354 and https://github.com/toss/slash/issues/449

I agree with [this answer](https://github.com/toss/slash/pull/355#issuecomment-1873193681). `click` event works fine on touchable screen too, so there is no need to have a `touch` event listener.

I believe another solution might be adding `e.preventDefault()` for the `touch` event. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events):
> ... [event.preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) to keep the browser from continuing to process the touch event (this also **prevents a mouse event from _also_ being delivered**).

However, I think this is a bit more over-engineering... so I decided to go with the first solution.

## PR Checklist

- [✅] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
