### PR TITLE
feat(SwitchCase): Allow enum type for 'value' prop

### DIFF
--- a/packages/react/react/src/components/SwitchCase/SwitchCase.en.md
+++ b/packages/react/react/src/components/SwitchCase/SwitchCase.en.md
@@ -1,10 +1,10 @@
 # SwitchCase
 
-Components that can use the switch-case syntax declaratively
+This is a component that allows you to use the switch-case syntax declaratively. The Case type can accept string, number, and enum.
 
 ## Example
 
-```jsx
+```tsx
 <SwitchCase
   value={status}
   // Depending on whether the status value is `'a'`, `'b'`, or `'c'`, the components below will be rendered.
@@ -13,7 +13,23 @@ Components that can use the switch-case syntax declaratively
     b: <TypeB />,
     c: <TypeC />,
   }}
-  // If the status value is nothing, this component will be rendered.
+  // If the status value does not match any case, this component will be rendered.
   defaultComponent={<Default />}
+/>
+
+enum Status {
+  A = 'a',
+  B = 'b',
+  C = 'c',
+}
+
+<SwitchCase
+  value={Status.A}
+  // Depending on whether the Status value is `Status.A`, `Status.B`, or `Status.C`, the components below will be rendered.
+  caseBy={{
+    [Status.A]: <TypeA />,
+    [Status.B]: <TypeB />,
+    [Status.C]: <TypeC />,
+  }}
 />
 ```

--- a/packages/react/react/src/components/SwitchCase/SwitchCase.ko.md
+++ b/packages/react/react/src/components/SwitchCase/SwitchCase.ko.md
@@ -1,10 +1,11 @@
 # SwitchCase
 
-switch-case 구문을 선언적으로 사용할 수 있는 컴포넌트입니다
+switch-case 구문을 선언적으로 사용할 수 있는 컴포넌트입니다.
+`Case` 타입은 `string`, `number`, `enum`을 모두 받을 수 있습니다.
 
 ## Example
 
-```jsx
+```tsx
 <SwitchCase
   value={status}
   // status 값이 `'a'`, `'b'`, `'c'` 인지에 따라서 아래 컴포넌트가 render 됩니다.
@@ -15,5 +16,21 @@ switch-case 구문을 선언적으로 사용할 수 있는 컴포넌트입니다
   }}
   // status 값이 아무것도 해당되지 않는 경우, 이 컴포넌트가 render 됩니다.
   defaultComponent={<Default />}
+/>
+
+enum Status {
+  A = 'a',
+  B = 'b',
+  C = 'c',
+}
+
+<SwitchCase
+  value={Status.A}
+  // Status 값이 `Status.A`, `Status.B`, `Status.C` 인지에 따라서 아래 컴포넌트가 render 됩니다.
+  caseBy={{
+    [Status.A]: <TypeA />,
+    [Status.B]: <TypeB />,
+    [Status.C]: <TypeC />,
+  }}
 />
 ```

--- a/packages/react/react/src/components/SwitchCase/SwitchCase.tsx
+++ b/packages/react/react/src/components/SwitchCase/SwitchCase.tsx
@@ -1,11 +1,12 @@
-interface Props<Case extends string | number> {
+type EnumKeys<E> = E extends Record<infer K, number | string> ? K : never;
+
+interface Props<Case extends string | number | EnumKeys<any>> {
   caseBy: Partial<Record<Case, JSX.Element | null>>;
   value: Case;
   defaultComponent?: JSX.Element | null;
 }
 
-/** @tossdocs-ignore */
-export function SwitchCase<Case extends string | number>({
+export function SwitchCase<Case extends string | number | EnumKeys<any>>({
   value,
   caseBy,
   defaultComponent: defaultComponent = null,

--- a/packages/react/react/src/components/SwitchCase/index.test.tsx
+++ b/packages/react/react/src/components/SwitchCase/index.test.tsx
@@ -1,6 +1,11 @@
 import { render } from '@testing-library/react';
 import { SwitchCase } from '.';
 
+enum TestEnum {
+  A = 'a',
+  B = 'b',
+}
+
 describe('SwitchCase', () => {
   function prepare(key: string) {
     return render(
@@ -34,5 +39,41 @@ describe('SwitchCase', () => {
     expect(controls.queryByText('Hello A')).not.toBeInTheDocument();
     expect(controls.queryByText('Hello B')).not.toBeInTheDocument();
     expect(controls.getByText('Default')).toBeInTheDocument();
+  });
+
+  describe('SwitchCase with enum', () => {
+    function prepare(key: TestEnum) {
+      return render(
+        <SwitchCase
+          value={key}
+          caseBy={{
+            [TestEnum.A]: <>Hello A</>,
+            [TestEnum.B]: <>Hello B</>,
+          }}
+          defaultComponent={<>Default</>}
+        />
+      );
+    }
+
+    it(`should render 'Hello A' when the value is 'a'.`, () => {
+      const controls = prepare(TestEnum.A);
+
+      expect(controls.getByText('Hello A')).toBeInTheDocument();
+    });
+
+    it(`should not render 'Hello B' when the value is 'a'.`, () => {
+      const controls = prepare(TestEnum.A);
+
+      expect(controls.getByText('Hello A')).toBeInTheDocument();
+      expect(controls.queryByText('Hello B')).not.toBeInTheDocument();
+    });
+
+    it(`should render 'Default' if no satisfying value is provided.`, () => {
+      const controls = prepare('cc' as TestEnum);
+
+      expect(controls.queryByText('Hello A')).not.toBeInTheDocument();
+      expect(controls.queryByText('Hello B')).not.toBeInTheDocument();
+      expect(controls.getByText('Default')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Overview

This PR enhances the SwitchCase component by allowing it to accept enum type for the value prop. This change provides more flexibility in using the SwitchCase component. The PR also includes updates to the test cases and documentation to reflect this new feature.


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
