### PR TITLE
fix(@toss/react): add useOutsideClickEffect dependency for preventing keep add and remove eventlistener

### DIFF
--- a/packages/react/react/src/hooks/useOutsideClickEffect.ts
+++ b/packages/react/react/src/hooks/useOutsideClickEffect.ts
@@ -1,5 +1,6 @@
 import { isNotNil } from '@toss/utils';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
+import { usePreservedCallback } from './usePreservedCallback';
 
 type OneOrMore<T> = T | T[];
 
@@ -11,24 +12,21 @@ export function useOutsideClickEffect(container: OneOrMore<HTMLElement | null>, 
     containers.current = (Array.isArray(container) ? container : [container]).filter(isNotNil);
   }, [container]);
 
-  const handleDocumentClick = useCallback(
-    ({ target }: MouseEvent | TouchEvent) => {
-      if (target === null) {
-        return;
-      }
+  const handleDocumentClick = usePreservedCallback(({ target }: MouseEvent | TouchEvent) => {
+    if (target === null) {
+      return;
+    }
 
-      if (containers.current.length === 0) {
-        return;
-      }
+    if (containers.current.length === 0) {
+      return;
+    }
 
-      if (containers.current.some(x => x.contains(target as Node))) {
-        return;
-      }
+    if (containers.current.some(x => x.contains(target as Node))) {
+      return;
+    }
 
-      callback();
-    },
-    [callback]
-  );
+    callback();
+  });
 
   useEffect(() => {
     document.addEventListener('click', handleDocumentClick);
@@ -38,5 +36,5 @@ export function useOutsideClickEffect(container: OneOrMore<HTMLElement | null>, 
       document.removeEventListener('click', handleDocumentClick);
       document.removeEventListener('touchstart', handleDocumentClick);
     };
-  });
+  }, [handleDocumentClick]);
 }


### PR DESCRIPTION
## Overview
I asked about [useOutsideClickEffect](https://github.com/toss/slash/issues/449#issue-2201872644)'s dependency for preventing keep add and remove event listener
and I agree with [this solution](https://github.com/toss/slash/issues/449#issuecomment-2014699197)
so I applied it on `useOutsideClickEffect`
<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
