### PR TITLE
fix(@toss/use-query-param): add extenion .js to import next/router

### DIFF
--- a/packages/react/use-query-param/src/hooks/useNextRouter.ts
+++ b/packages/react/use-query-param/src/hooks/useNextRouter.ts
@@ -1,5 +1,5 @@
 /** @tossdocs-ignore */
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/router.js';
 import { waitForRouterReady } from '../utils/waitForRouterReady';
 
 interface Options {

--- a/packages/react/use-query-param/src/utils/waitForRouterReady.ts
+++ b/packages/react/use-query-param/src/utils/waitForRouterReady.ts
@@ -1,5 +1,5 @@
 /** @tossdocs-ignore */
-import Router from 'next/router';
+import Router from 'next/router.js';
 
 export function waitForRouterReady() {
   return new Promise<void>(resolve => {


### PR DESCRIPTION
## Overview

![스크린샷 2024-04-22 오후 10 43 25](https://github.com/toss/slash/assets/37887690/65547d03-6392-4034-95cc-5404fa24dadb)

When i tried to use @toss/use-funnel, i got a error `Cannot find module next/router`

I found that `@toss/use-funnel`  depended on `@toss/use-query-param` and fixed it by adding the extension.

My Next version is v13 and i found a similar case that fixed this issue in [@toss/use-funnel](https://github.com/toss/slash/pull/312/files#diff-22b2ba85b7dc35c45d33851a75ae5751fa89db39d5776559c02b086baaa26168). 



## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
