### PR TITLE
chore: remove footer i18n on docusaurus-theme-classic

### DIFF
--- a/docs/i18n/en/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/en/docusaurus-theme-classic/footer.json
@@ -14,9 +14,5 @@
   "link.item.label.GitHub": {
     "message": "GitHub",
     "description": "The label of footer link with label=GitHub linking to https://github.com/toss/slash"
-  },
-  "copyright": {
-    "message": "Copyright © 2022 Viva Republica, Inc.",
-    "description": "The footer copyright"
   }
 }

--- a/docs/i18n/ko/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/ko/docusaurus-theme-classic/footer.json
@@ -11,10 +11,6 @@
     "message": "GitHub",
     "description": "The label of footer link with label=GitHub linking to https://github.com/toss/slash"
   },
-  "copyright": {
-    "message": "Copyright © 2022 Viva Republica, Inc.",
-    "description": "The footer copyright"
-  },
   "link.title.More": {
     "message": "더보기",
     "description": "The title of the footer links column with title=More in the footer"


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->
 
copyright year is fixed because of i18n footer options.
remove these options so that copyright year would be current year.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
