### PR TITLE
fix(@toss/react): FullHeight component change hook

### DIFF
--- a/packages/react/emotion-utils/package.json
+++ b/packages/react/emotion-utils/package.json
@@ -42,6 +42,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@toss/jest": "workspace:^",
+    "@toss/react": "workspace:^1.7.0",
     "@toss/rollup-config": "workspace:^0.2.0",
     "@types/babel__core": "^7",
     "@types/jest": "^28.1.8",

--- a/packages/react/emotion-utils/src/FullHeight.tsx
+++ b/packages/react/emotion-utils/src/FullHeight.tsx
@@ -1,10 +1,9 @@
 /** @tossdocs-ignore */
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { isServer } from '@toss/utils';
-import { HTMLAttributes, ReactNode, useEffect, useLayoutEffect, useState } from 'react';
+import { useIsomorphicLayoutEffect } from '@toss/react';
 
-const useIsomorphicLayoutEffect = isServer() ? useEffect : useLayoutEffect;
+import { HTMLAttributes, ReactNode, useState } from 'react';
 
 export function FullHeight({ children, ...props }: { children: ReactNode } & HTMLAttributes<HTMLDivElement>) {
   const [height, setHeight] = useState(0);


### PR DESCRIPTION
## Overview

Replace the `useIsomorphicLayoutEffect` previously declared in the component with a custom hook implemented in **@toss/react**.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
