### PR TITLE
feat(@toss/react): useInterval stop/resume support

### DIFF
--- a/packages/react/react/src/hooks/useInterval.en.md
+++ b/packages/react/react/src/hooks/useInterval.en.md
@@ -1,7 +1,7 @@
 # useInterval
 
 This hook makes it easy to use window.setInterval.
-Stop and resume interval with 'resume' and 'stop'.
+
 ```ts
 // Please enter a number or IntervalOptions
 type IntervalOptions =
@@ -11,11 +11,13 @@ type IntervalOptions =
       delay: number | null;
       // If it is specified as false, the Effect will run immediately.
       trailing?: boolean;
+      // If it is false, the effect is not performed.
+      enabled?: boolean;
     };
 ```
 
 ## Example
 
 ```ts
-const { intervalRunning, stop, continueTimer } = useInterval(updateServerTime, { delay: interval });
+useInterval(updateServerTime, { delay: interval });
 ```

--- a/packages/react/react/src/hooks/useInterval.en.md
+++ b/packages/react/react/src/hooks/useInterval.en.md
@@ -1,7 +1,7 @@
 # useInterval
 
 This hook makes it easy to use window.setInterval.
-
+Stop and resume interval with 'resume' and 'stop'.
 ```ts
 // Please enter a number or IntervalOptions
 type IntervalOptions =
@@ -17,5 +17,5 @@ type IntervalOptions =
 ## Example
 
 ```ts
-useInterval(updateServerTime, { delay: interval });
+const { intervalRunning, stop, continueTimer } = useInterval(updateServerTime, { delay: interval });
 ```

--- a/packages/react/react/src/hooks/useInterval.ko.md
+++ b/packages/react/react/src/hooks/useInterval.ko.md
@@ -1,6 +1,7 @@
 # useInterval
 
 window.setInterval 를 쉽게 사용할 수 있는 hook 입니다.
+'resume', 'stop'을 통해 interval을 중지, 재개합니다.
 
 ```ts
 // number 혹은 IntervalOptions를 입력해주세요
@@ -17,5 +18,5 @@ type IntervalOptions =
 ## Example
 
 ```ts
-useInterval(updateServerTime, { delay: interval });
+const { intervalRunning, stop, continueTimer } = useInterval(updateServerTime, { delay: interval });
 ```

--- a/packages/react/react/src/hooks/useInterval.ko.md
+++ b/packages/react/react/src/hooks/useInterval.ko.md
@@ -1,7 +1,6 @@
 # useInterval
 
 window.setInterval 를 쉽게 사용할 수 있는 hook 입니다.
-'resume', 'stop'을 통해 interval을 중지, 재개합니다.
 
 ```ts
 // number 혹은 IntervalOptions를 입력해주세요
@@ -12,11 +11,13 @@ type IntervalOptions =
       delay: number | null;
       // 만약 false로 지정된 경우 Effect를 즉시 실행시킵니다.
       trailing?: boolean;
+      // 만약 false인 지정된 경우, Effect가 수행되지 않습니다.
+      enabled?: boolean;
     };
 ```
 
 ## Example
 
 ```ts
-const { intervalRunning, stop, continueTimer } = useInterval(updateServerTime, { delay: interval });
+useInterval(updateServerTime, { delay: interval });
 ```

--- a/packages/react/react/src/hooks/useInterval.spec.tsx
+++ b/packages/react/react/src/hooks/useInterval.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useInterval } from './useInterval';
 
 jest.useFakeTimers();
@@ -7,13 +7,11 @@ describe('useInterval', () => {
   it('Should execute a callback every time a set time passes.', () => {
     const callback = jest.fn();
 
-    const { result } = renderHook(() =>
+    renderHook(() =>
       useInterval(callback, {
         delay: 3000,
       })
     );
-
-    expect(result.current.intervalRunning).toBe(true);
 
     jest.advanceTimersByTime(2900);
 
@@ -64,30 +62,26 @@ describe('useInterval', () => {
     expect(callback).toBeCalledTimes(1);
   });
 
-  it('Should not execute the callback when stop function has been called.', () => {
+  it('Should not execute the callback when enable option is false', () => {
     const callback = jest.fn();
 
-    const { result } = renderHook(() => useInterval(callback, { delay: 3000 }));
-
-    act(() => result.current.stop());
-
+    renderHook(() => useInterval(callback, { delay: 3000, enabled: false }));
     jest.advanceTimersByTime(3000);
 
     expect(callback).not.toBeCalled();
   });
 
-  it('Should resume the interval When continueTimer function is called.', () => {
+  it('Should resume the interval When enable options become true.', () => {
     const callback = jest.fn();
+    const props = { delay: 3000, enabled: false };
 
-    const { result } = renderHook(() => useInterval(callback, { delay: 3000 }));
-
-    act(() => result.current.stop());
-
+    const { rerender } = renderHook(() => useInterval(callback, props));
     jest.advanceTimersByTime(3000);
 
     expect(callback).not.toBeCalled();
 
-    act(() => result.current.resume());
+    props.enabled = true;
+    rerender();
 
     jest.advanceTimersByTime(3000);
 

--- a/packages/react/react/src/hooks/useInterval.spec.tsx
+++ b/packages/react/react/src/hooks/useInterval.spec.tsx
@@ -63,12 +63,16 @@ describe('useInterval', () => {
   });
 
   it('Should not execute the callback when enable option is false', () => {
+    const savedInterval = Window.setinterval;
+    Window.setInterval = jest.fn();
     const callback = jest.fn();
 
     renderHook(() => useInterval(callback, { delay: 3000, enabled: false }));
+    expect(Window.setInterval).not.toBeCalled();
     jest.advanceTimersByTime(3000);
 
     expect(callback).not.toBeCalled();
+    Window.setInterval = savedInterval;
   });
 
   it('Should resume the interval When enable options become true.', () => {

--- a/packages/react/react/src/hooks/useInterval.spec.tsx
+++ b/packages/react/react/src/hooks/useInterval.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useInterval } from './useInterval';
 
 jest.useFakeTimers();
@@ -7,11 +7,13 @@ describe('useInterval', () => {
   it('Should execute a callback every time a set time passes.', () => {
     const callback = jest.fn();
 
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useInterval(callback, {
         delay: 3000,
       })
     );
+
+    expect(result.current.intervalRunning).toBe(true);
 
     jest.advanceTimersByTime(2900);
 
@@ -60,5 +62,35 @@ describe('useInterval', () => {
     renderHook(() => useInterval(callback, { delay: 3000, trailing: false }));
 
     expect(callback).toBeCalledTimes(1);
+  });
+
+  it('Should not execute the callback when stop function has been called.', () => {
+    const callback = jest.fn();
+
+    const { result } = renderHook(() => useInterval(callback, { delay: 3000 }));
+
+    act(() => result.current.stop());
+
+    jest.advanceTimersByTime(3000);
+
+    expect(callback).not.toBeCalled();
+  });
+
+  it('Should resume the interval When continueTimer function is called.', () => {
+    const callback = jest.fn();
+
+    const { result } = renderHook(() => useInterval(callback, { delay: 3000 }));
+
+    act(() => result.current.stop());
+
+    jest.advanceTimersByTime(3000);
+
+    expect(callback).not.toBeCalled();
+
+    act(() => result.current.resume());
+
+    jest.advanceTimersByTime(3000);
+
+    expect(callback).toBeCalled();
   });
 });

--- a/packages/react/react/src/hooks/useInterval.ts
+++ b/packages/react/react/src/hooks/useInterval.ts
@@ -1,5 +1,5 @@
 import { noop } from '@toss/utils';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { usePreservedCallback } from './usePreservedCallback';
 
 type IntervalOptions =
@@ -11,9 +11,13 @@ type IntervalOptions =
 
 /** @tossdocs-ignore */
 export function useInterval(callback: () => void, options: IntervalOptions) {
+  const [running, setRunning] = useState(true);
   const delay = typeof options === 'number' ? options : options.delay;
   const trailing = typeof options === 'number' ? undefined : options.trailing;
   const savedCallback = usePreservedCallback(callback ?? noop);
+
+  const stop = () => setRunning(false);
+  const resume = () => setRunning(true);
 
   useEffect(() => {
     if (trailing === false) {
@@ -29,10 +33,12 @@ export function useInterval(callback: () => void, options: IntervalOptions) {
     }
 
     function tick() {
-      savedCallback();
+      if (running) savedCallback();
     }
 
     const id = window.setInterval(tick, delay);
     return () => window.clearInterval(id);
-  }, [delay, savedCallback]);
+  }, [delay, savedCallback, running]);
+
+  return { intervalRunning: running, stop, resume };
 }

--- a/packages/react/react/src/hooks/useInterval.ts
+++ b/packages/react/react/src/hooks/useInterval.ts
@@ -30,17 +30,13 @@ export function useInterval(callback: () => void, options: IntervalOptions) {
   }, [trailing, savedCallback]);
 
   useEffect(() => {
-    if (delay === null) {
+    if (delay === null || !enabled) {
       return () => {
         return;
       };
     }
 
-    function tick() {
-      if (enabled) savedCallback();
-    }
-
-    const id = window.setInterval(tick, delay);
+    const id = window.setInterval(savedCallback, delay);
     return () => window.clearInterval(id);
   }, [delay, savedCallback, enabled]);
 }


### PR DESCRIPTION
## Overview

When using Interval, sometimes you need to stop and resume the interval.

When configuring the carousel, if auto-turning is implemented through useInterval, the interval must be stopped when the user is in the middle of the slide, and the interval must be resumed when the slide is completed.

In this case, I suggest that if it returns the factors presented above in the hook, it will be easy to implement!

Accordingly, why don't you return the stop, resume function, and intervalRunning status.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
