### PR TITLE
fix(@toss/react): @toss/react State synchronization issue in useStorageState

### DIFF
--- a/packages/react/react/src/hooks/useStorageState.spec.ts
+++ b/packages/react/react/src/hooks/useStorageState.spec.ts
@@ -131,7 +131,7 @@ describe('useLocalStorageState는', () => {
     expect(result.current[0]).toEqual({ foo: 'baz' });
   });
 
-  it('setState를 했을 때 해당 키를 의존하는 useStorageState의 값이 동기화된다. . ', () => {
+  it('setState를 했을 때 해당 키를 의존하는 useStorageState의 값이 동기화된다.', () => {
     const key = '@@render-synchronization';
     const storage = createMockStorage();
 

--- a/packages/react/react/src/hooks/useStorageState.spec.ts
+++ b/packages/react/react/src/hooks/useStorageState.spec.ts
@@ -130,6 +130,36 @@ describe('useLocalStorageState는', () => {
 
     expect(result.current[0]).toEqual({ foo: 'baz' });
   });
+
+  it('setState를 했을 때 해당 키를 의존하는 useStorageState의 값이 동기화된다. . ', () => {
+    const key = '@@render-synchronization';
+    const storage = createMockStorage();
+
+    const renderA = () => renderHook(() => useStorageState<T>(key, { storage }));
+    const renderB = () => renderHook(() => useStorageState<T>(key, { storage }));
+
+    const mockReturnValue = { foo: 'bar' };
+
+    storage.get.mockReturnValue(JSON.stringify(mockReturnValue));
+
+    const { result: resultA } = renderA();
+    const { result: resultB } = renderB();
+
+    expect(resultA.current[0]).toEqual(mockReturnValue);
+    expect(resultB.current[0]).toEqual(mockReturnValue);
+
+    const valueToSet = { foo: 'baz' };
+
+    act(() => {
+      const [, set] = resultA.current;
+
+      storage.get.mockReturnValue(JSON.stringify(valueToSet));
+      set(valueToSet);
+    });
+
+    expect(resultA.current[0]).toEqual(valueToSet);
+    expect(resultB.current[0]).toEqual(valueToSet);
+  });
 });
 
 function createMockStorage() {

--- a/packages/react/react/src/hooks/useStorageState.ts
+++ b/packages/react/react/src/hooks/useStorageState.ts
@@ -1,6 +1,6 @@
 /** @tossdocs-ignore */
 import { safeLocalStorage, Storage } from '@toss/storage';
-import { SetStateAction, useCallback, useState } from 'react';
+import { SetStateAction, useCallback, useEffect, useState } from 'react';
 
 type ToPrimitive<T> = T extends string ? string : T extends number ? number : T extends boolean ? boolean : never;
 type ToObject<T> = T extends unknown[] | Record<string, unknown> ? T : never;
@@ -56,6 +56,10 @@ export function useStorageState<T>(
     }
   }, [defaultValue, key, storage]);
 
+  useStorageEvent(key, () => {
+    setState(getValue);
+  });
+
   const [state, setState] = useState<Serializable<T> | undefined>(getValue);
 
   const set = useCallback(
@@ -69,6 +73,13 @@ export function useStorageState<T>(
           storage.set(key, JSON.stringify(nextValue));
         }
 
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key,
+            newValue: JSON.stringify(nextValue),
+          })
+        );
+
         return nextValue;
       });
     },
@@ -80,4 +91,20 @@ export function useStorageState<T>(
   }, [defaultValue, getValue]);
 
   return [state, set, refresh] as const;
+}
+
+function useStorageEvent(key: string, callback: () => void) {
+  useEffect(() => {
+    const handler = (event: StorageEvent) => {
+      if (event.key === key) {
+        callback();
+      }
+    };
+
+    window.addEventListener('storage', handler);
+
+    return () => {
+      window.removeEventListener('storage', handler);
+    };
+  }, [key, callback]);
 }


### PR DESCRIPTION
## Overview
Fixed #477

Fix useStorageState hook where state updates are not properly synchronized across components. 

issue detail: When a value is initialized  until the set function is explicitly called. Additionally, invoking the refresh method in one component does not update the state in other components using the same storage key.
<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
