### PR TITLE
fix(@toss/react): more declarative `ErroBoundary` fallback

### DIFF
--- a/packages/react/async-boundary/src/AsyncBoundary.tsx
+++ b/packages/react/async-boundary/src/AsyncBoundary.tsx
@@ -7,7 +7,7 @@ type SuspenseProps = Omit<ComponentProps<typeof Suspense>, 'fallback'>;
 
 type Props = SuspenseProps &
   ErrorBoundaryProps & {
-    rejectedFallback: ComponentProps<typeof ErrorBoundary>['renderFallback'];
+    rejectedFallback?: ComponentProps<typeof ErrorBoundary>['renderFallback'];
     pendingFallback: ComponentProps<typeof Suspense>['fallback'];
   };
 

--- a/packages/react/error-boundary/src/ErrorBoundary.tsx
+++ b/packages/react/error-boundary/src/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 /** @tossdocs-ignore */
+import { buildContext } from '@toss/react';
 import { isDifferentArray } from '@toss/utils';
 import {
   Component,
@@ -17,6 +18,11 @@ import {
 import { ErrorBoundaryGroupContext } from './ErrorBoundaryGroup';
 import { ComponentPropsWithoutChildren } from './types/index';
 
+export const [ErrorBoundaryProvider, useErrorBoundaryContext] = buildContext<{
+  error: Error | null;
+  reset: () => void;
+}>('ErrorBoundaryContext');
+
 type RenderFallbackProps<ErrorType extends Error = Error> = {
   error: ErrorType;
   reset: () => void;
@@ -31,7 +37,7 @@ type Props<ErrorType extends Error = Error> = {
    */
   resetKeys?: unknown[];
   onReset?(): void;
-  renderFallback: RenderFallbackType;
+  renderFallback?: RenderFallbackType;
   onError?(error: ErrorType, info: ErrorInfo): void;
   /*
    * @description 이 ErrorBoundary Context에서 처리하지 않고 throw해줄 error의 조건을 명시할 callback
@@ -94,18 +100,29 @@ class BaseErrorBoundary extends Component<PropsWithRef<PropsWithChildren<Props>>
     }
   }
 
-  render() {
-    const { children, renderFallback } = this.props;
+  generateRenderedChildren() {
     const { error } = this.state;
+    const { children, renderFallback } = this.props;
 
-    if (error != null) {
+    if (error != null && renderFallback) {
       return renderFallback({
         error,
         reset: this.resetErrorBoundary,
       });
     }
-
     return children;
+  }
+
+  render() {
+    const { error } = this.state;
+
+    const renderedChildren = this.generateRenderedChildren();
+    const ErrorboundaryProviderProps = {
+      error,
+      reset: this.resetErrorBoundary,
+    };
+
+    return <ErrorBoundaryProvider {...ErrorboundaryProviderProps}>{renderedChildren}</ErrorBoundaryProvider>;
   }
 }
 


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

1. More declarative `fallback`.
2. `renderFallback` type is a `function`, so stringify is not possible when `SSR`. (especially `server component`)
    - `reset` can be passed to subcomponents to support SSR.
3. `CustomFallback` component and `renderFallback` are used together, `renderFallback` be rendered for DX enhancement.


### AS-IS

- Not Supported in `server component`


```jsx
<ErrorBoundary renderFallback={({ error }) => <div>{error.message}</div>}>
  <SomeComponent />
</ErrorBoundary>
```


### TO-BE

- `CustomFallback`

```jsx
function CustomFallback ({ children }: { children: JSX.Element }): JSX.Element {
  const { error } = useErrorBoundaryContext();

  if (error != null) {
     return <div>error..</div>;
  }

  return <div>{children}</div>;
};
```

<br/>

```jsx
<ErrorBoundary>
  <CustomFallback>
    <SomeComponent />
  </CustomFallback>
</ErrorBoundary>
```

### Rendered `renderFallback`

- (both `renderFallback`, `<CustomFallback/>`)

```jsx
<ErrorBoundary renderFallback={({ error }) => <div>{error.message}</div>}>
  <CustomFallback>
    <SomeComponent />
  </CustomFallback>
</ErrorBoundary>
```

<br/>

## `AsyncBoundary`

```jsx
<AsyncBoundary pendingFallback={<div>loading...</div>}>
  <CustomFallback>
    <SomeComponent />
  </CustomFallback>
</AsyncBoundary>
```



## PR Checklist

- [x] I read and included theses actions below
- [x] All test Passed (ac912ed9edc3d4f75583200396ea8f0c0a3c3e98)

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
