### PR TITLE
feat(@toss/react): OutsideClick Component

### DIFF
--- a/packages/react/react/src/components/OutsideClick/OutsideClick.en.md
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.en.md
@@ -1,0 +1,65 @@
+---
+title: OutsideClick
+---
+
+# OutsideClick
+
+A component that declaratively handles the functionality of `useOutsideClickEffect`.
+
+If you click outside the component wrapped in `OutsideClick`, `callback` is executed.
+
+```tsx
+<OutsideClick callback={callback}>{children}</OutsideClick>
+```
+
+<br/>
+
+## Attributes
+
+You can assign an `ElementType` by assigning a type to `<OutsideClick>`.
+
+You can use `HTMLAttributes` as needed.
+
+```tsx
+function Component() {
+  return (
+    <OutsideClick<HTMLInputElement, 'input'>
+      callback={() => {
+        console.log('outside clicked!');
+      }}
+      {/* input disabled */}
+      disabled
+    >
+      Inside
+    </OutsideClick>
+  );
+}
+```
+
+## Examples
+
+import { Sandpack } from "@codesandbox/sandpack-react";
+
+<!-- prettier-ignore -->
+<Sandpack
+  template="react"
+  files={{
+    '/App.js': `import { OutsideClick } from '@toss/react';\n
+export default function App() {
+  return (
+    <>
+      <OutsideClick callback={() => alert('Outside Clicked!')}>
+        Inside
+      </OutsideClick>
+      <div>Click me</div>
+    </>
+  );
+}
+`
+  }}
+  customSetup={{
+    dependencies: {
+      '@toss/react': 'latest',
+    },
+  }}
+/>

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.en.md
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.en.md
@@ -16,25 +16,47 @@ If you click outside the component wrapped in `OutsideClick`, `callback` is exec
 
 ## Attributes
 
-You can assign an `ElementType` by assigning a type to `<OutsideClick>`.
+You can assign an `ElementType` to `<OutsideClick>`.
 
 You can use `HTMLAttributes` as needed.
 
 ```tsx
 function Component() {
   return (
-    <OutsideClick<HTMLInputElement, 'input'>
+    <OutsideClick<'input'>
+      as="input"
       callback={() => {
         console.log('outside clicked!');
       }}
-      {/* input disabled */}
-      disabled
-    >
-      Inside
-    </OutsideClick>
+    />
   );
 }
 ```
+
+<br/>
+
+### Caveats
+
+```ts
+type NonHaveChildElements =
+  | 'input'
+  | 'textarea'
+  | 'img'
+  | 'br'
+  | 'hr'
+  | 'meta'
+  | 'link'
+  | 'base'
+  | 'col'
+  | 'embed'
+  | 'source'
+  | 'track'
+  | 'wbr';
+```
+
+Tags belonging to `NonHaveChildElements` use `self-closing tags` because they do not have children.
+
+<br/>
 
 ## Examples
 

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.ko.md
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.ko.md
@@ -16,25 +16,47 @@ title: OutsideClick
 
 ## Attributes
 
-`<OutsideClick>`에 타입을 할당하여 `ElementType`을 지정할 수 있습니다.
+제네릭을 제공하여`<OutsideClick>`에 `ElementType`을 지정할 수 있습니다.
 
 필요한 `HTMLAttributes`를 사용할 수 있습니다.
 
 ```tsx
 function Component() {
   return (
-    <OutsideClick<HTMLInputElement, 'input'>
+    <OutsideClick<'input'>
+      as="input"
       callback={() => {
         console.log('outside clicked!');
       }}
-      {/* input disabled */}
-      disabled
-    >
-      Inside
-    </OutsideClick>
+    />
   );
 }
 ```
+
+<br/>
+
+### Caveats
+
+```ts
+type NonHaveChildElements =
+  | 'input'
+  | 'textarea'
+  | 'img'
+  | 'br'
+  | 'hr'
+  | 'meta'
+  | 'link'
+  | 'base'
+  | 'col'
+  | 'embed'
+  | 'source'
+  | 'track'
+  | 'wbr';
+```
+
+`NonHaveChildElements`에 속한 태그는 자식이 존재하지 않으므로 `self-closing tags`를 사용합니다.
+
+<br/>
 
 ## Examples
 

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.ko.md
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.ko.md
@@ -1,0 +1,65 @@
+---
+title: OutsideClick
+---
+
+# OutsideClick
+
+`useOutsideClickEffect`의 기능을 선언적으로 처리하는 컴포넌트입니다.
+
+`OutsideClick`로 감싸진 컴포넌트 외부를 클릭하는 경우 `callback`이 실행됩니다.
+
+```tsx
+<OutsideClick callback={callback}>{children}</OutsideClick>
+```
+
+<br/>
+
+## Attributes
+
+`<OutsideClick>`에 타입을 할당하여 `ElementType`을 지정할 수 있습니다.
+
+필요한 `HTMLAttributes`를 사용할 수 있습니다.
+
+```tsx
+function Component() {
+  return (
+    <OutsideClick<HTMLInputElement, 'input'>
+      callback={() => {
+        console.log('outside clicked!');
+      }}
+      {/* input disabled */}
+      disabled
+    >
+      Inside
+    </OutsideClick>
+  );
+}
+```
+
+## Examples
+
+import { Sandpack } from "@codesandbox/sandpack-react";
+
+<!-- prettier-ignore -->
+<Sandpack
+  template="react"
+  files={{
+    '/App.js': `import { OutsideClick } from '@toss/react';\n
+export default function App() {
+  return (
+    <>
+      <OutsideClick callback={() => alert('Outside Clicked!')}>
+        Inside
+      </OutsideClick>
+      <div>Click me</div>
+    </>
+  );
+}
+`
+  }}
+  customSetup={{
+    dependencies: {
+      '@toss/react': 'latest',
+    },
+  }}
+/>

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.test.tsx
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OutsideClick } from './OutsideClick';
+
+describe('OutsideClick', () => {
+  it('should call the callback when an event occurs outside the component', async () => {
+    const onEffect = jest.fn();
+
+    render(
+      <>
+        <OutsideClick callback={onEffect}>
+          <div data-testid="inside">inside</div>
+        </OutsideClick>
+
+        <div data-testid="outside">outside</div>
+      </>
+    );
+
+    await userEvent.click(screen.getByTestId('inside'));
+    expect(onEffect).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByTestId('outside'));
+
+    await waitFor(() => {
+      expect(onEffect).toHaveBeenCalledTimes(1);
+    });
+
+    document.body.click();
+
+    await waitFor(() => {
+      expect(onEffect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should not call the callback when an event occurs inside the component', async () => {
+    const onEffect = jest.fn();
+    render(
+      <OutsideClick callback={onEffect}>
+        <div data-testid="inside">inside</div>
+      </OutsideClick>
+    );
+
+    await userEvent.click(screen.getByTestId('inside'));
+    expect(onEffect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.test.tsx
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
 import { OutsideClick } from './OutsideClick';
 
 describe('OutsideClick', () => {
@@ -42,5 +43,19 @@ describe('OutsideClick', () => {
 
     await userEvent.click(screen.getByTestId('inside'));
     expect(onEffect).not.toHaveBeenCalled();
+  });
+
+  it('should expose internal DOM element through external ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    const onEffect = jest.fn();
+
+    render(
+      <OutsideClick ref={ref} callback={onEffect}>
+        <div>Inside Component</div>
+      </OutsideClick>
+    );
+
+    const insideElement = screen.getByText('Inside Component');
+    expect(ref.current?.contains(insideElement)).toBeTruthy();
   });
 });

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ElementType, PropsWithChildren, ReactNode, useState } from 'react';
+import { ComponentProps, ElementType, forwardRef, ReactNode, useState } from 'react';
 import { useOutsideClickEffect } from '../../index';
 
 type NonHaveChildElements =
@@ -20,23 +20,20 @@ type NoChildren<Tag extends ElementType> = Tag extends NonHaveChildElements
   ? { children?: never }
   : { children: ReactNode };
 
-type AsRequired<Tag extends ElementType> = Tag extends 'div' ? { as?: Tag } : { as: Tag };
+type TagRequired<Tag extends ElementType> = Tag extends 'div' ? { as?: Tag } : { as: Tag };
 
 type AllowedTagName<Tag extends ElementType> = Tag extends keyof HTMLElementTagNameMap
   ? HTMLElementTagNameMap[Tag]
   : HTMLElement;
 
-type OutsideClickProp<Tag extends ElementType> = PropsWithChildren<ComponentProps<Tag>> &
-  AsRequired<Tag> &
+type OutsideClickProp<Tag extends ElementType> = ComponentProps<Tag> &
+  TagRequired<Tag> &
   NoChildren<Tag> & {
     callback: () => void;
   };
 
-export default function OutsideClick<
-  Tag extends ElementType = 'div',
-  E extends AllowedTagName<Tag> = AllowedTagName<Tag>
->({ as, children, callback, ...props }: OutsideClickProp<Tag>) {
-  const [element, setElement] = useState<E | null>(null);
+function OutsideClick<Tag extends ElementType = 'div'>({ as, children, callback, ...props }: OutsideClickProp<Tag>) {
+  const [element, setElement] = useState<AllowedTagName<Tag> | null>(null);
 
   useOutsideClickEffect(element, callback);
 
@@ -48,3 +45,7 @@ export default function OutsideClick<
     </Component>
   );
 }
+
+const OutsideClickWithForwardRef = forwardRef(OutsideClick) as typeof OutsideClick;
+
+export { OutsideClickWithForwardRef as OutsideClick };

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
@@ -18,7 +18,7 @@ type NonHaveChildElements =
 
 type NoChildren<Tag extends ElementType> = Tag extends NonHaveChildElements
   ? { children?: never }
-  : { children?: ReactNode };
+  : { children: ReactNode };
 
 type AsRequired<Tag extends ElementType> = Tag extends 'div' ? { as?: Tag } : { as: Tag };
 

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
@@ -1,17 +1,41 @@
-import { ComponentProps, ElementType, ReactNode, useState } from 'react';
+import { ComponentProps, ElementType, PropsWithChildren, ReactNode, useState } from 'react';
 import { useOutsideClickEffect } from '../../index';
 
-type OutsideClickProp<Tag extends ElementType> = ComponentProps<Tag> & { children: ReactNode } & {
-  as?: Tag;
-  callback: () => void;
-};
+type NonHaveChildElements =
+  | 'input'
+  | 'textarea'
+  | 'img'
+  | 'br'
+  | 'hr'
+  | 'meta'
+  | 'link'
+  | 'base'
+  | 'col'
+  | 'embed'
+  | 'source'
+  | 'track'
+  | 'wbr';
 
-export function OutsideClick<E extends HTMLElement = HTMLDivElement, Tag extends ElementType = 'div'>({
-  as,
-  children,
-  callback,
-  ...props
-}: OutsideClickProp<Tag>) {
+type NoChildren<Tag extends ElementType> = Tag extends NonHaveChildElements
+  ? { children?: never }
+  : { children?: ReactNode };
+
+type AsRequired<Tag extends ElementType> = Tag extends 'div' ? { as?: Tag } : { as: Tag };
+
+type AllowedTagName<Tag extends ElementType> = Tag extends keyof HTMLElementTagNameMap
+  ? HTMLElementTagNameMap[Tag]
+  : HTMLElement;
+
+type OutsideClickProp<Tag extends ElementType> = PropsWithChildren<ComponentProps<Tag>> &
+  AsRequired<Tag> &
+  NoChildren<Tag> & {
+    callback: () => void;
+  };
+
+export default function OutsideClick<
+  Tag extends ElementType = 'div',
+  E extends AllowedTagName<Tag> = AllowedTagName<Tag>
+>({ as, children, callback, ...props }: OutsideClickProp<Tag>) {
   const [element, setElement] = useState<E | null>(null);
 
   useOutsideClickEffect(element, callback);

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
@@ -1,4 +1,5 @@
-import { ComponentProps, ElementType, forwardRef, ReactNode, useState } from 'react';
+import { ComponentProps, ElementType, ForwardedRef, forwardRef, ReactNode, useState } from 'react';
+import { useCombinedRefs } from '../../hooks';
 import { useOutsideClickEffect } from '../../index';
 
 type NonHaveChildElements =
@@ -32,7 +33,10 @@ type OutsideClickProp<Tag extends ElementType> = ComponentProps<Tag> &
     callback: () => void;
   };
 
-function OutsideClick<Tag extends ElementType = 'div'>({ as, children, callback, ...props }: OutsideClickProp<Tag>) {
+function OutsideClick<Tag extends ElementType = 'div'>(
+  { as, children, callback, ...props }: OutsideClickProp<Tag>,
+  ref: ForwardedRef<any>
+) {
   const [element, setElement] = useState<AllowedTagName<Tag> | null>(null);
 
   useOutsideClickEffect(element, callback);
@@ -40,7 +44,7 @@ function OutsideClick<Tag extends ElementType = 'div'>({ as, children, callback,
   const Component = as || 'div';
 
   return (
-    <Component ref={setElement} {...props}>
+    <Component ref={useCombinedRefs(setElement, ref)} {...props}>
       {children}
     </Component>
   );

--- a/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
@@ -1,0 +1,26 @@
+import { ComponentProps, ElementType, ReactNode, useState } from 'react';
+import { useOutsideClickEffect } from '../../index';
+
+type OutsideClickProp<Tag extends ElementType> = ComponentProps<Tag> & { children: ReactNode } & {
+  as?: Tag;
+  callback: () => void;
+};
+
+export function OutsideClick<E extends HTMLElement = HTMLDivElement, Tag extends ElementType = 'div'>({
+  as,
+  children,
+  callback,
+  ...props
+}: OutsideClickProp<Tag>) {
+  const [element, setElement] = useState<E | null>(null);
+
+  useOutsideClickEffect(element, callback);
+
+  const Component = as || 'div';
+
+  return (
+    <Component ref={setElement} {...props}>
+      {children}
+    </Component>
+  );
+}

--- a/packages/react/react/src/components/OutsideClick/index.ts
+++ b/packages/react/react/src/components/OutsideClick/index.ts
@@ -1,0 +1,1 @@
+export * from './OutsideClick';

--- a/packages/react/react/src/components/index.ts
+++ b/packages/react/react/src/components/index.ts
@@ -3,5 +3,6 @@ export * from './ClickArea';
 export * from './DebounceClick';
 export * from './HiddenHeading';
 export * from './OpenGraph';
+export * from './OutsideClick';
 export * from './Separated';
 export * from './SwitchCase';


### PR DESCRIPTION
## AS-IS

```jsx
const [wrapperEl, setWrapperEl] = useState(null);

useOutsideClickEffect(wrapperEl, () => {
  console.log('outside clicked!');
});
return <div ref={setWrapperEl}></div>;
```

## TO-BE

```jsx
<OutsideClick callback={() => console.log('outside clicked!')}>
  <div>something</div>
</OutsideClick>
```

<br/>

## Overview

A component that declaratively handles the functionality of `useOutsideClickEffect`.
If you click outside the component wrapped in `OutsideClick`, `callback` is executed.

```jsx
<OutsideClick callback={callback}>{children}</OutsideClick>
```


## Attributes

Assign an generic `ElementType` to `<OutsideClick>`.
Use `HTMLAttributes` as needed.

```jsx
function Component() {
  return (
    <OutsideClick<'input'>
      callback={() => console.log('outside clicked')}
      as="input"
      disabled
    />
  );
}
```

<br/>

- [x] Documentation completed. (96da885bb062a21a51acea0bc816478e58cf9019)
- [x] Test code completed. (42cc85c830b28538de69603cc9a3435a3dfed364) 


<br/>

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
