### PR TITLE
docs(@toss/storage): fix broken links in Korean documentation for storage functions

### DIFF
--- a/packages/common/storage/src/safeLocalStorage.ko.md
+++ b/packages/common/storage/src/safeLocalStorage.ko.md
@@ -4,7 +4,7 @@ title: safeLocalStorage
 
 # safeLocalStorage
 
-[generateStorage](https://slash.page/ko/libraries/common/storage/src/generatestorage.i18n)로 생성된 local storage accessor 입니다.
+[generateStorage](https://slash.page/ko/libraries/common/storage/src/generateStorage.i18n)로 생성된 local storage accessor 입니다.
 
 ## Examples
 

--- a/packages/common/storage/src/safeSessionStorage.ko.md
+++ b/packages/common/storage/src/safeSessionStorage.ko.md
@@ -4,7 +4,7 @@ title: safeSessionStorage
 
 # safeSessionStorage
 
-[generateSessionStorage](https://slash.page/ko/libraries/common/storage/src/generatesessionstorage.i18n)로 생성된 session storage accessor 입니다.
+[generateSessionStorage](https://slash.page/ko/libraries/common/storage/src/generateSessionStorage.i18n)로 생성된 session storage accessor 입니다.
 
 ## Examples
 

--- a/packages/common/storage/src/typed/createTypedLocalStorage.ko.md
+++ b/packages/common/storage/src/typed/createTypedLocalStorage.ko.md
@@ -4,7 +4,7 @@ title: createTypedLocalStorage
 
 # createTypedLocalStorage
 
-local storage를 사용하는 [TypedStorage](https://slash.page/ko/libraries/common/storage/src/typed/storages/typedstorage.i18n) 인스턴스를 생성합니다. `initialValue`의 타입에 맞추어 적절한 타입의 인스턴스가 생성됩니다.
+local storage를 사용하는 [TypedStorage](https://slash.page/ko/libraries/common/storage/src/typed/storages/TypedStorage.i18n) 인스턴스를 생성합니다. `initialValue`의 타입에 맞추어 적절한 타입의 인스턴스가 생성됩니다.
 
 ## Note
 

--- a/packages/common/storage/src/typed/createTypedSessionStorage.ko.md
+++ b/packages/common/storage/src/typed/createTypedSessionStorage.ko.md
@@ -4,7 +4,7 @@ title: createTypedSessionStorage
 
 # createTypedSessionStorage
 
-session storage를 사용하는 [TypedStorage](https://slash.page/ko/libraries/common/storage/src/typed/storages/typedstorage.i18n) 인스턴스를 생성합니다. `initialValue`의 타입에 맞추어 적절한 타입의 인스턴스가 생성됩니다.
+session storage를 사용하는 [TypedStorage](https://slash.page/ko/libraries/common/storage/src/typed/storages/TypedStorage.i18n) 인스턴스를 생성합니다. `initialValue`의 타입에 맞추어 적절한 타입의 인스턴스가 생성됩니다.
 
 ## Note
 

--- a/packages/common/storage/src/typed/storages/NumberTypedStorage.ko.md
+++ b/packages/common/storage/src/typed/storages/NumberTypedStorage.ko.md
@@ -4,7 +4,7 @@ title: NumberTypedStorage
 
 # NumberTypedStorage
 
-[TypedStorage](https://slash.page/ko/libraries/common/storage/src/typed/storages/typedstorage.i18n)를 확장하여, number 타입에 specific한 유틸 메소드들을 제공합니다.
+[TypedStorage](https://slash.page/ko/libraries/common/storage/src/typed/storages/TypedStorage.i18n)를 확장하여, number 타입에 specific한 유틸 메소드들을 제공합니다.
 
 ## Note
 


### PR DESCRIPTION
## Overview

Hello, While studying the slash `@toss/storage` functions, I encountered broken links in the Korean documentation for the `@toss/storage` library. 

This fixes these broken links caused by misspellings that resulted in `Page Not Found` errors. The following corrections have been made to ensure proper navigation.

![image](https://github.com/toss/slash/assets/52266597/ea6d6aac-b9d6-4f63-9690-5acb64872be8)

- `generatestorage` -> `generateStorage`
- `generatesessionstorage` -> `generateSessionStorage`
- `typedstorage` -> `TypedStorage`

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
