### PR TITLE
docs(@toss/react): useInterval korean docs fix typo

### DIFF
--- a/packages/react/react/src/hooks/useInterval.en.md
+++ b/packages/react/react/src/hooks/useInterval.en.md
@@ -11,7 +11,7 @@ type IntervalOptions =
       delay: number | null;
       // If it is specified as false, the Effect will run immediately.
       trailing?: boolean;
-      // If it is false, the effect is not performed.
+      // If it is specified as false, the Effect will not run.
       enabled?: boolean;
     };
 ```

--- a/packages/react/react/src/hooks/useInterval.ko.md
+++ b/packages/react/react/src/hooks/useInterval.ko.md
@@ -3,7 +3,7 @@
 window.setInterval 를 쉽게 사용할 수 있는 hook 입니다.
 
 ```ts
-// number 혹은 IntervalOptions를 입력해주세요
+// number 혹은 IntervalOptions를 입력해주세요.
 type IntervalOptions =
   | number
   | {
@@ -11,7 +11,7 @@ type IntervalOptions =
       delay: number | null;
       // 만약 false로 지정된 경우 Effect를 즉시 실행시킵니다.
       trailing?: boolean;
-      // 만약 false인 지정된 경우, Effect가 수행되지 않습니다.
+      // 만약 false로 지정된 경우 Effect가 수행되지 않습니다.
       enabled?: boolean;
     };
 ```


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

While checking the docs with the previous PR(#476) applied, I noticed a typo in the Korean document that I had missed before, so I corrected it. Additionally, I standardized the wording in the English docs.

I apologize for any inconvenience caused by my oversight.


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
