### PR TITLE
fix(@toss/utils): replace 힇 to 힣

### DIFF
--- a/packages/common/utils/src/Masker.ts
+++ b/packages/common/utils/src/Masker.ts
@@ -28,7 +28,7 @@ function maskName(name: string) {
 function maskExceptForEdge(text: string, edgeSize: number) {
   return (
     text.slice(0, edgeSize) +
-    text.slice(edgeSize, text.length - edgeSize).replace(/[a-zA-Z가-힇]/g, '*') +
+    text.slice(edgeSize, text.length - edgeSize).replace(/[a-zA-Z가-힣]/g, '*') +
     text.slice(text.length - edgeSize, text.length)
   );
 }


### PR DESCRIPTION
## Overview

When using regular expressions to determine Korean characters, we are using [가-힣]. However, in the maskExceptForEdge method, the library is using “힇”. '힣's unicode value is more higher than '힇'. So if you want to contain whole hangul, you should use '힣'

Fix the typo and send a PR. 

## Attach an example of how you implemented the bug. 
![image](https://github.com/toss/slash/assets/111696934/b848e6df-749e-475b-b882-4b880bac39db)


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
