### PR TITLE
fix(@toss/react): useStorageState - set default value to storage

### DIFF
--- a/packages/react/react/src/hooks/useStorageState.ts
+++ b/packages/react/react/src/hooks/useStorageState.ts
@@ -90,6 +90,12 @@ export function useStorageState<T>(
     setState(getValue() ?? defaultValue);
   }, [defaultValue, getValue]);
 
+  useEffect(() => {
+    if (defaultValue) {
+      set(getValue());
+    }
+  }, [set, getValue, defaultValue]);
+
   return [state, set, refresh] as const;
 }
 

--- a/packages/react/react/src/hooks/useStorageState.ts
+++ b/packages/react/react/src/hooks/useStorageState.ts
@@ -91,7 +91,7 @@ export function useStorageState<T>(
   }, [defaultValue, getValue]);
 
   useEffect(() => {
-    if (defaultValue) {
+    if (defaultValue != null) {
       set(getValue());
     }
   }, [set, getValue, defaultValue]);


### PR DESCRIPTION
## Overview
FIX #421

Set the value in storage when the value is initialized to the default value.


### Example
[![Edit use-session-storage](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/devbox/use-session-storage-53d9p3?embed=1&file=%2Fsrc%2FApp.tsx)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
