### PR TITLE
docs: Add suspensive to Project Status in README

### DIFF
--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -12,9 +12,10 @@ Slash 라이브러리는 [토스](https://toss.im)에서 사용하는 TypeScript
 ## 프로젝트 상태
 
 - Slash는 레거시 프로젝트이고, 현재 유지보수되고 있지 않습니다.
-- Slash의 여러 유용한 기능들은 [es-hangul](https://github.com/toss/es-hangul), [es-toolkit](https://github.com/toss/es-toolkit)과 같은 별도의 패키지들로 분리될 예정이며, 현재 개발 진행 중입니다.
-  - es-hangul은 쉽게 한글을 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.
-  - es-toolkit은 높은 성능과 작은 번들 사이즈, 강력한 타입을 자랑하는 현대적인 JavaScript 유틸리티 라이브러리입니다.
+- Slash의 여러 유용한 기능들은 여러 개의 별도 패키지들로 분리될 예정이며, 현재 개발 진행 중입니다.
+  - [es-hangul](https://github.com/toss/es-hangul)은 쉽게 한글을 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.
+  - [es-toolkit](https://github.com/toss/es-toolkit)은 높은 성능과 작은 번들 사이즈, 강력한 타입을 자랑하는 현대적인 JavaScript 유틸리티 라이브러리입니다.
+  - [suspensive](https://github.com/toss/suspensive)는 React의 Suspense와 ErrorBoundary를 우아하게 다루는 JavaScript 라이브러리입니다.
 - Slash 기여를 원하시는 분들은 Slash가 아닌 위 패키지들에 기여를 부탁드립니다.
 
 ## 기여하기

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Slash is a collection of TypeScript/JavaScript packages used in [Toss](https://t
 ## Project Status
 
 - Slash is a legacy project and is not currently being maintained.
-- Many of Slash's useful features will be separated into separate packages, such as [es-hangul](https://github.com/toss/es-hangul) and [es-toolkit](https://github.com/toss/es-toolkit), which are currently under development.
-  - es-hangul is a JavaScript library that makes it easy to work with Hangul.
-  - es-toolkit is a modern JavaScript utility library with high performance, small bundle size, and strong types.
+- Many of Slash's useful features will be separated into several individual packages that are currently under development.
+  - [es-hangul](https://github.com/toss/es-hangul) is a JavaScript library that makes it easy to work with Hangul.
+  - [es-toolkit](https://github.com/toss/es-toolkit) is a modern JavaScript utility library with high performance, small bundle size, and strong types.
+  - [suspensive](https://github.com/toss/suspensive) is a JavaScript library that elegantly handles React's suspense and error boundaries.
 - If you would like to contribute to Slash, please contribute to these packages, not Slash.
 
 ## Contributing


### PR DESCRIPTION
## Overview

Add information about [suspensive](https://github.com/toss/suspensive), which has now joined the Toss organization, to the Project Status section of the README.

Also, update the location of the links to the package repositories.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
