### PR TITLE
chore(@toss/react): remove duplicated page from OutsideClick by adding @tossdocs-ignore

### DIFF
--- a/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
+++ b/packages/react/react/src/components/OutsideClick/OutsideClick.tsx
@@ -1,6 +1,6 @@
+/** @tossdocs-ignore */
 import { ComponentProps, ElementType, ForwardedRef, forwardRef, ReactNode, useState } from 'react';
-import { useCombinedRefs } from '../../hooks';
-import { useOutsideClickEffect } from '../../index';
+import { useCombinedRefs, useOutsideClickEffect } from '../../hooks';
 
 type NonHaveChildElements =
   | 'input'

--- a/packages/react/react/src/components/OutsideClick/index.ts
+++ b/packages/react/react/src/components/OutsideClick/index.ts
@@ -1,1 +1,2 @@
+/** @tossdocs-ignore */
 export * from './OutsideClick';


### PR DESCRIPTION

## Overview
- remove duplicated page from OutsideClick by adding @tossdocs-ignore

<img width="303" alt="image" src="https://github.com/toss/slash/assets/60910665/b1560c12-0fa2-41b5-9c02-6446826e7936">

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
