### PR TITLE
docs(@toss/use-funnel): add missing comment symbol to Defining the funnel

### DIFF
--- a/packages/react/use-funnel/README.md
+++ b/packages/react/use-funnel/README.md
@@ -49,7 +49,7 @@ return (
     </Funnel.Step>
 
     <Funnel.Step name="enter social security number">
-      <EnterSocialSecurityNumberStep /> Render when ?funnel-step="enter social security number"
+      <EnterSocialSecurityNumberStep /> // Render when ?funnel-step="enter social security number"
     </Funnel.Step>
 
     <Funnel.Step name="done">


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

The code block in [Defining the funnel](https://www.slash.page/libraries/react/use-funnel/README.i18n) has comments without comment symbols. So I added a comment symbol.

<img width="808" alt="image" src="https://github.com/toss/slash/assets/88662637/2df9bdf7-c17c-4f8c-a167-4cf05ba7a745">

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
