### PR TITLE
docs: Add overlay-kit to Project Status in README

### DIFF
--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -16,6 +16,7 @@ Slash 라이브러리는 [토스](https://toss.im)에서 사용하는 TypeScript
   - [es-hangul](https://github.com/toss/es-hangul)은 쉽게 한글을 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.
   - [es-toolkit](https://github.com/toss/es-toolkit)은 높은 성능과 작은 번들 사이즈, 강력한 타입을 자랑하는 현대적인 JavaScript 유틸리티 라이브러리입니다.
   - [suspensive](https://github.com/toss/suspensive)는 React의 Suspense와 ErrorBoundary를 우아하게 다루는 JavaScript 라이브러리입니다.
+  - [overlay-kit](https://github.com/toss/overlay-kit)은 React의 오버레이를 선언적으로 다루는 JavaScript 라이브러리입니다.
 - Slash 기여를 원하시는 분들은 Slash가 아닌 위 패키지들에 기여를 부탁드립니다.
 
 ## 기여하기

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Slash is a collection of TypeScript/JavaScript packages used in [Toss](https://t
   - [es-hangul](https://github.com/toss/es-hangul) is a JavaScript library that makes it easy to work with Hangul.
   - [es-toolkit](https://github.com/toss/es-toolkit) is a modern JavaScript utility library with high performance, small bundle size, and strong types.
   - [suspensive](https://github.com/toss/suspensive) is a JavaScript library that elegantly handles React's suspense and error boundaries.
+  - [overlay-kit](https://github.com/toss/overlay-kit) is a JavaScript library that manages overlays declaratively in React.
 - If you would like to contribute to Slash, please contribute to these packages, not Slash.
 
 ## Contributing


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->
Add information about [overlay-kit](https://github.com/toss/overlay-kit), which has now released v1.0.0, to the Project Status section of the README.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
