### PR TITLE
feat(@toss/react):allow null value in SwitchCase component

### DIFF
--- a/packages/react/react/src/components/SwitchCase/SwitchCase.tsx
+++ b/packages/react/react/src/components/SwitchCase/SwitchCase.tsx
@@ -1,6 +1,6 @@
 interface Props<Case extends string | number> {
   caseBy: Partial<Record<Case, JSX.Element | null>>;
-  value: Case;
+  value: Case | null;
   defaultComponent?: JSX.Element | null;
 }
 


### PR DESCRIPTION
## Overview

Refactored the 'SwitchCase' component to accept 'null' as a valid value for 'value' prop, enhancing flexibility and usability

- Updated the 'Props' interface for the 'SwitchCase' component to allow 'value' to be of type 'Case | null'. This change ensures that the component can handle scenarios where 'value' is explicitly set to null.
- Adjusted conditional logic within the 'SwitchCase' function to correctly handle cases where 'value' is null, retruning 'defaultComponent' when appropriate.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
