### PR TITLE
fix(@toss/utils): When iOS Request Desktop Website is enabled, there is an issue with the userAgent.

### DIFF
--- a/packages/common/utils/src/device/isIOS.spec.ts
+++ b/packages/common/utils/src/device/isIOS.spec.ts
@@ -15,6 +15,15 @@ describe('isIOS', () => {
     expect(isIOS()).toBe(true);
   });
 
+  it('should return true for iOS with Request Desktop Website enabled', () => {
+    jest.spyOn(serverCheckModule, 'isServer').mockReturnValue(false);
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'Intel Mac', writable: true });
+    Object.defineProperty(window.navigator, 'maxTouchPoints', { value: 1 });
+    Object.defineProperty(window.screen, 'availWidth', { value: 375 });
+
+    expect(isIOS()).toBe(true);
+  });
+
   it('should return false for non-iOS user agent', () => {
     jest.spyOn(serverCheckModule, 'isServer').mockReturnValue(false);
     Object.defineProperty(window.navigator, 'userAgent', { value: 'Android', writable: true });

--- a/packages/common/utils/src/device/isIOS.ts
+++ b/packages/common/utils/src/device/isIOS.ts
@@ -6,5 +6,11 @@ export function isIOS() {
     return false;
   }
 
-  return navigator.userAgent.match(/ipad|iphone/i) !== null;
+  return (
+    navigator.userAgent.match(/iPad|iPhone/i) !== null ||
+    (navigator.userAgent.match(/Macintosh|Intel Mac/i) !== null &&
+      navigator.maxTouchPoints > 0 &&
+      window.screen.availWidth >= 375 &&
+      window.screen.availWidth <= 1366)
+  );
 }


### PR DESCRIPTION
## Overview
[https://forums.developer.apple.com/forums/thread/119186](https://forums.developer.apple.com/forums/thread/119186)
When the "Request Desktop Website" option is enabled in iOS Safari, there is an issue with the userAgent being incorrect.

- **iOS Version:** 17.5
- **Device Model:** iPhone 15 Pro
- **Browser:** Safari

## Reproduction Steps

1. Open Safari on iPhone 15 Pro.
2. Navigate to any website (safari).
3. Enable the "Request Desktop Website" option in Safari settings.
4. Check the userAgent string using developer tools or JavaScript.

## Expect
`Mozilla/5.0 (iPhone; ...`

## Result
![image](https://github.com/toss/slash/assets/101170386/1e404d23-d9f6-463d-aa31-83e0801dd8aa)


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
