### PR TITLE
docs: add project status section

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-pages/index.md
@@ -112,6 +112,16 @@ hide_table_of_contents: true
 - [**@toss/utils**](https://slash.page/ko/libraries/common/utils/README.i18n) 는 Node.js와 브라우저 환경에서 사용할 수 있는 간단하고 모던한 유틸리티 함수를 제공해요.
 - [**@toss/hangul**](https://slash.page/ko/libraries/common/hangul/README.i18n) 는 [hangul](https://en.wikipedia.org/wiki/Hangul) 문자를 다루기 위한 유틸리티 함수를 제공해요.
 
+## 프로젝트 상태
+
+- Slash는 레거시 프로젝트이고, 현재 유지보수되고 있지 않습니다.
+- Slash의 여러 유용한 기능들은 여러 개의 별도 패키지들로 분리될 예정이며, 현재 개발 진행 중입니다.
+  - [es-hangul](https://github.com/toss/es-hangul)은 쉽게 한글을 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.
+  - [es-toolkit](https://github.com/toss/es-toolkit)은 높은 성능과 작은 번들 사이즈, 강력한 타입을 자랑하는 현대적인 JavaScript 유틸리티 라이브러리입니다.
+  - [suspensive](https://github.com/toss/suspensive)는 React의 Suspense와 ErrorBoundary를 우아하게 다루는 JavaScript 라이브러리입니다.
+  - [use-funnel](https://github.com/toss/use-funnel)은 강력하고 안전한 단계별 상태 관리 React 라이브러리입니다.
+- Slash 기여를 원하시는 분들은 Slash가 아닌 위 패키지들에 기여를 부탁드립니다.
+
 <div style={{ height: 24 }} />
 
 ## 더 읽기

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -116,6 +116,16 @@ hide_table_of_contents: true
 - [**@toss/utils**](https://slash.page/libraries/common/utils/README.i18n) provides simple and modern helper libraries which can be used both in Node.js and browser environments.
 - [**@toss/hangul**](https://slash.page/libraries/common/hangul/README.i18n) provides utility functions to manipulate [hangul](https://en.wikipedia.org/wiki/Hangul) characters.
 
+## Project Status
+
+- Slash is a legacy project and is not currently being maintained.
+- Many of Slash's useful features will be separated into several individual packages that are currently under development.
+  - [es-hangul](https://github.com/toss/es-hangul) is a JavaScript library that makes it easy to work with Hangul.
+  - [es-toolkit](https://github.com/toss/es-toolkit) is a modern JavaScript utility library with high performance, small bundle size, and strong types.
+  - [suspensive](https://github.com/toss/suspensive) is a JavaScript library that elegantly handles React's suspense and error boundaries.
+  - [use-funnel](https://github.com/toss/use-funnel) is a powerful and safe step-by-step state management React library
+- If you would like to contribute to Slash, please contribute to these packages, not Slash.
+
 <div style={{ height: 24 }} />
 
 ## More reading


### PR DESCRIPTION
## Overview
- I hope that by adding a "Project Status" section to the main page of Slash, interest in Slash will extend to other Toss libraries, fostering ecosystem development and encouraging active contributions.
- When searching for "Toss library" on Google, Slash appears at the top of the results. It would be ideal if this could also lead users to other Toss libraries.

| AS-IS | TO-BE |
| --- | --- |
|<img width="896" alt="image" src="https://github.com/user-attachments/assets/1b72d1c7-01f2-4f82-a092-ddd7eba9af57" />|<img width="899" alt="image" src="https://github.com/user-attachments/assets/5df7cfa0-7d45-4e63-b6c3-1895fb2f313b" />|

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
