### PR TITLE
fix(use-funnel): fix invalid URL in migration guide

### DIFF
--- a/packages/react/use-funnel/README.ko.md
+++ b/packages/react/use-funnel/README.ko.md
@@ -13,7 +13,7 @@
 ### 추천 조치 사항:
 
 - 새 기능과 구현 세부사항에 대해서는 [@use-funnel](https://use-funnel.slash.page) 문서를 참고해 주세요.
-- `@toss/use-funnel` 을 `@use-funnel` 으로 마이그레이션을 하고 싶다면 [문서]([https://use-funnel.slash.page/docs/migration])를 참고해 주세요.
+- `@toss/use-funnel` 을 `@use-funnel` 으로 마이그레이션을 하고 싶다면 [문서](https://use-funnel.slash.page/docs/migration)를 참고해 주세요.
 
 지속적인 지원과 이해에 감사드립니다.
 


### PR DESCRIPTION
## Overview

Fix an issue where migration guide link on the `use-funnel` page


<!--
    A clear and concise description of what this pr is about.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
