### PR TITLE
docs(use-overlay): clarify the document that useOverlay is not limited to Next.js

### DIFF
--- a/packages/react/use-overlay/src/useOverlay.ko.md
+++ b/packages/react/use-overlay/src/useOverlay.ko.md
@@ -5,7 +5,7 @@ title: useOverlay
 `useOverlay`는 Overlay를 선언적으로 다루기 위한 유틸리티입니다.
 
 - Overlay란? BottomSheet과 Dialog처럼 별도의 UI 레이어에 띄우는 컴포넌트
-- 사용하기 위해선 \_app.tsx에 `<OverlayProvider />`를 추가해야 합니다.
+- 사용하기 위해선 최상단(root) 컴포넌트에 `<OverlayProvider />`를 추가해야 합니다.
 - useOverlay를 여러 번 호출해서 여러 개의 Overlay를 만들 수 있습니다.
 - Promise와 함께 사용할 수 있습니다.
 


### PR DESCRIPTION
## Overview

In the Korean documentation, it specifies `_app.tsx`, but since useOverlay is not a hook exclusive to the Next.js environment and the English version of the documentation refers to the “root component” instead, I believe it would be better to update this.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
