### PR TITLE
docs(@toss/utils): update example for formatToKRW to reflect correct output

### DIFF
--- a/packages/common/utils/src/Numbers_formatToKRW.en.md
+++ b/packages/common/utils/src/Numbers_formatToKRW.en.md
@@ -27,6 +27,6 @@ function formatToKRW(
 ```typescript
 formatToKRW(13209802); // '1,320만 9,802원'
 formatToKRW(13209802, { floorUnit: 10000 }); // '1,320만원'
-formatToKRW(13209802, { ceilUnit: 10000 }); // '1,320만 9,802원'
+formatToKRW(13209802, { ceilUnit: 10000 }); // '1,321만원'
 formatToKRW(13200000, { formatAllDigits: true }); // '천3백2십만원'
 ```


### PR DESCRIPTION
## Overview

This pull request updates the documentation for the `formatToKRW` function to reflect a corrected behavior when using the `ceilUnit` option.

* Documentation update:
  * [`packages/common/utils/src/Numbers_formatToKRW.en.md`](diffhunk://#diff-a4808abfb1ba80c94c7b92e02ba0d3fff83d38438b5b8dc9eaf4e9501137f6abL30-R30): Updated the example output for `formatToKRW` with the `ceilUnit` option to reflect the corrected behavior, showing that values are now rounded up to the nearest unit.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
