### PR TITLE
docs(@toss/use-overaly): fix typo in Korean documetation

### DIFF
--- a/packages/react/use-overlay/src/useOverlay.ko.md
+++ b/packages/react/use-overlay/src/useOverlay.ko.md
@@ -4,7 +4,7 @@ title: useOverlay
 
 `useOverlay`는 Overlay를 선언적으로 다루기 위한 유틸리티입니다.
 
-- Overlay란? BottomSheet과 Dialog처럼 별도의 UI 레이어에 띄우는 컴포넌트
+- Overlay란? BottomSheet와 Dialog처럼 별도의 UI 레이어에 띄우는 컴포넌트
 - 사용하기 위해선 \_app.tsx에 `<OverlayProvider />`를 추가해야 합니다.
 - useOverlay를 여러 번 호출해서 여러 개의 Overlay를 만들 수 있습니다.
 - Promise와 함께 사용할 수 있습니다.


### PR DESCRIPTION
## Overview

### Changes
Fixed a grammatical error in Korean documentation.

- Line 7 in `packages/react/use-overlay/src/useOverlay.ko.md`
- Changed "BottomSheet과 Dialog" to "BottomSheet와 Dialog"

### Reason for the change
Fixed the Korean particle usage to follow proper Korean grammar. "과" is used after nouns with final consonants, while "와" is used after nouns without final consonants.

### Files changed
- `packages/react/use-overlay/src/useOverlay.ko.md`

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
