### PR TITLE
docs(@toss/date): Fix typo in getDateDistanceText docs

### DIFF
--- a/packages/common/date/src/docs/getDateDistanceText.en.md
+++ b/packages/common/date/src/docs/getDateDistanceText.en.md
@@ -1,6 +1,6 @@
 # getDateDistanceText
 
-Formats a value returned by [getDateDistance()](https://slash.page/libraries/common/date/src/docs/getdatedistance.i18n).
+Formats a value returned by [getDateDistance()](https://slash.page/libraries/common/date/src/docs/getDateDistance.i18n).
 
 ```typescript
 function getDateDistanceText(

--- a/packages/common/date/src/docs/getDateDistanceText.ko.md
+++ b/packages/common/date/src/docs/getDateDistanceText.ko.md
@@ -1,6 +1,6 @@
 # getDateDistanceText
 
-[getDateDistance()](https://slash.page/ko/libraries/common/date/src/docs/getdatedistance.i18n)가 반환하는 값을 인자로 받아서, 문자열로 포맷팅 해줍니다.
+[getDateDistance()](https://slash.page/ko/libraries/common/date/src/docs/getDateDistance.i18n)가 반환하는 값을 인자로 받아서, 문자열로 포맷팅 해줍니다.
 
 ```typescript
 function getDateDistanceText(


### PR DESCRIPTION
## Overview

This PR fixes a small typo in the documentation for getDateDistanceText.

- Corrected the link path from `~/getdatedistance.i18n` to the proper `~/getDateDistance.i18n` in both English and Korean docs.
- This correction is expected to make the links work properly.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/slash/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
